### PR TITLE
feat(autoware_tensorrt_vad): rename lidar2img to vad_base2img

### DIFF
--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/input_converter/transform_matrix_converter.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/input_converter/transform_matrix_converter.hpp
@@ -9,7 +9,7 @@
 
 namespace autoware::tensorrt_vad::vad_interface {
 
-using Lidar2ImgData = std::vector<float>;
+using VadBase2ImgData = std::vector<float>;
 
 /**
  * @brief InputTransformMatrixConverter handles vad base_link to image (camera optical link) transformation matrix calculation
@@ -34,9 +34,9 @@ public:
    * @param camera_infos Vector of ROS CameraInfo messages from multiple cameras
    * @param scale_width Width scaling factor for image resizing
    * @param scale_height Height scaling factor for image resizing
-   * @return Lidar2ImgData Flattened transformation matrices for all cameras
+   * @return VadBase2ImgData Flattened transformation matrices for all cameras
    */
-  Lidar2ImgData process_lidar2img(
+  VadBase2ImgData process_lidar2img(
     const std::vector<sensor_msgs::msg::CameraInfo::ConstSharedPtr>& camera_infos,
     const float scale_width, const float scale_height) const;
 

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/input_converter/transform_matrix_converter.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/input_converter/transform_matrix_converter.hpp
@@ -16,7 +16,7 @@ using VadBase2ImgData = std::vector<float>;
  * 
  * This class processes camera calibration data to create transformation matrices:
  * - TF lookup for base_link to camera frame transformations
- * - Camera intrinsics matrix processing (viewpad creation)
+ * - Camera intrinsics matrix processing (cam2img matrix creation)
  * - Image scaling application for resized images
  * - vad base_link to image (camera optical link) transformation matrix calculation and flattening
  */
@@ -42,11 +42,11 @@ public:
 
 private:
   /**
-   * @brief Create viewpad matrix from camera intrinsics
+   * @brief Create cam2img(4x4 camera_link to camera_optical_link matrix, as known as viewpad) matrix from camera intrinsics
    * @param camera_info Camera calibration information
-   * @return Eigen::Matrix4f 4x4 viewpad matrix with intrinsics and padding
+   * @return Eigen::Matrix4f 4x4 cam2img matrix with intrinsics and padding
    */
-  Eigen::Matrix4f create_viewpad(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& camera_info) const;
+  Eigen::Matrix4f create_cam2img(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& camera_info) const;
 
   /**
    * @brief Apply scaling transformation to vad base_link (coordinate used in VAD inference) to image (camera optical link) transformation matrix

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/input_converter/transform_matrix_converter.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/input_converter/transform_matrix_converter.hpp
@@ -30,13 +30,13 @@ public:
   InputTransformMatrixConverter(const CoordinateTransformer& coordinate_transformer, const VadInterfaceConfig& config);
 
   /**
-   * @brief Process camera info messages to generate lidar2img transformation matrices
+   * @brief Process camera info messages to generate vad base_link (coordinate used in VAD inference) to image (camera optical link) transformation matrices
    * @param camera_infos Vector of ROS CameraInfo messages from multiple cameras
    * @param scale_width Width scaling factor for image resizing
    * @param scale_height Height scaling factor for image resizing
    * @return VadBase2ImgData Flattened transformation matrices for all cameras
    */
-  VadBase2ImgData process_lidar2img(
+  VadBase2ImgData process_vad_base2img(
     const std::vector<sensor_msgs::msg::CameraInfo::ConstSharedPtr>& camera_infos,
     const float scale_width, const float scale_height) const;
 
@@ -49,13 +49,13 @@ private:
   Eigen::Matrix4f create_viewpad(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& camera_info) const;
 
   /**
-   * @brief Apply scaling transformation to lidar2img matrix
-   * @param lidar2img Original vad base_link to image (camera optical link) transformation matrix
+   * @brief Apply scaling transformation to vad base_link (coordinate used in VAD inference) to image (camera optical link) transformation matrix
+   * @param vad_base2img Original vad base_link to image (camera optical link) transformation matrix
    * @param scale_width Width scaling factor
    * @param scale_height Height scaling factor
    * @return Eigen::Matrix4f Scaled transformation matrix
    */
-  Eigen::Matrix4f apply_scaling(const Eigen::Matrix4f& lidar2img, const float scale_width, const float scale_height) const;
+  Eigen::Matrix4f apply_scaling(const Eigen::Matrix4f& vad_base2img, const float scale_width, const float scale_height) const;
 
   /**
    * @brief Convert 4x4 matrix to flattened vector in row-major order

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
@@ -117,7 +117,7 @@ struct VadOutputTopicData
 // Data structures for return values of each process_* method
 using CameraImagesData = std::vector<float>;
 using ShiftData = std::vector<float>;
-using Lidar2ImgData = std::vector<float>;
+using VadBase2ImgData = std::vector<float>;
 using CanBusData = std::vector<float>;
 
 /**
@@ -160,7 +160,7 @@ private:
   std::vector<float> prev_can_bus_;
 
   // Cached VAD base_link (coordinate used in VAD output trajectory) to camera transformation matrix
-  std::optional<Lidar2ImgData> vad_base2img_transform_;
+  std::optional<VadBase2ImgData> vad_base2img_transform_;
 };
 
 }  // namespace autoware::tensorrt_vad

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -93,7 +93,7 @@ struct VadInputData
   std::vector<float> shift_;
 
   // Transform matrix from LiDAR coordinate system to camera image coordinate system (img_metas.0[lidar2img])
-  std::vector<float> lidar2img_;
+  std::vector<float> vad_base2img_;
 
   // CAN-BUS data (vehicle state information: velocity, angular velocity, etc.) (img_metas.0[can_bus])
   std::vector<float> can_bus_;
@@ -284,7 +284,7 @@ private:
   void load_inputs(const VadInputData& vad_input, const std::string& head_name) {
     nets_["backbone"]->bindings["img"]->load(vad_input.camera_images_, stream_);
     nets_[head_name]->bindings["img_metas.0[shift]"]->load(vad_input.shift_, stream_);
-    nets_[head_name]->bindings["img_metas.0[lidar2img]"]->load(vad_input.lidar2img_, stream_);
+    nets_[head_name]->bindings["img_metas.0[lidar2img]"]->load(vad_input.vad_base2img_, stream_);
     nets_[head_name]->bindings["img_metas.0[can_bus]"]->load(vad_input.can_bus_, stream_);
 
     if (head_name == "head") {

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -92,7 +92,7 @@ struct VadInputData
   // Shift information (img_metas.0[shift])
   std::vector<float> shift_;
 
-  // Transform matrix from LiDAR coordinate system to camera image coordinate system (img_metas.0[lidar2img])
+  // Transform matrix from coordinate used in VAD inference to camera image coordinate system (img_metas.0[lidar2img])
   std::vector<float> vad_base2img_;
 
   // CAN-BUS data (vehicle state information: velocity, angular velocity, etc.) (img_metas.0[can_bus])

--- a/planning/autoware_tensorrt_vad/lib/input_converter/transform_matrix_converter.cpp
+++ b/planning/autoware_tensorrt_vad/lib/input_converter/transform_matrix_converter.cpp
@@ -48,7 +48,7 @@ std::vector<float> InputTransformMatrixConverter::matrix_to_flat(const Eigen::Ma
   return flat;
 }
 
-Lidar2ImgData InputTransformMatrixConverter::process_lidar2img(
+VadBase2ImgData InputTransformMatrixConverter::process_lidar2img(
   const std::vector<sensor_msgs::msg::CameraInfo::ConstSharedPtr>& camera_infos,
   const float scale_width, const float scale_height) const
 {

--- a/planning/autoware_tensorrt_vad/lib/input_converter/transform_matrix_converter.cpp
+++ b/planning/autoware_tensorrt_vad/lib/input_converter/transform_matrix_converter.cpp
@@ -28,12 +28,12 @@ Eigen::Matrix4f InputTransformMatrixConverter::create_viewpad(
 }
 
 Eigen::Matrix4f InputTransformMatrixConverter::apply_scaling(
-  const Eigen::Matrix4f& lidar2img, const float scale_width, const float scale_height) const
+  const Eigen::Matrix4f& vad_base2img, const float scale_width, const float scale_height) const
 {
   Eigen::Matrix4f scale_matrix = Eigen::Matrix4f::Identity();
   scale_matrix(0, 0) = scale_width;
   scale_matrix(1, 1) = scale_height;
-  return scale_matrix * lidar2img;
+  return scale_matrix * vad_base2img;
 }
 
 std::vector<float> InputTransformMatrixConverter::matrix_to_flat(const Eigen::Matrix4f& matrix) const
@@ -48,11 +48,11 @@ std::vector<float> InputTransformMatrixConverter::matrix_to_flat(const Eigen::Ma
   return flat;
 }
 
-VadBase2ImgData InputTransformMatrixConverter::process_lidar2img(
+VadBase2ImgData InputTransformMatrixConverter::process_vad_base2img(
   const std::vector<sensor_msgs::msg::CameraInfo::ConstSharedPtr>& camera_infos,
   const float scale_width, const float scale_height) const
 {
-  std::vector<float> frame_lidar2img(16 * 6, 0.0f); // Reserve space for 6 cameras
+  std::vector<float> frame_vad_base2img(16 * 6, 0.0f); // Reserve space for 6 cameras
 
   // Process each camera
   for (int32_t autoware_camera_id = 0; autoware_camera_id < 6; ++autoware_camera_id) {
@@ -72,25 +72,25 @@ VadBase2ImgData InputTransformMatrixConverter::process_lidar2img(
     Eigen::Matrix4f viewpad = create_viewpad(camera_infos[autoware_camera_id]);
     
     // Get vad2base transformation from config through coordinate transformer
-    // The coordinate transformer uses vad2base internally, but we need to access it for lidar2cam calculation
-    // Calculate lidar2cam transformation: viewpad * base2cam * vad2base
-    Eigen::Matrix4f lidar2cam_rt = base2cam * config_.vad2base;
-    Eigen::Matrix4f lidar2img = viewpad * lidar2cam_rt;
+    // The coordinate transformer uses vad2base internally, but we need to access it for vad2cam calculation
+    // Calculate vad2cam transformation: vad2img = cam2img * base2cam * vad2base
+    Eigen::Matrix4f vad2cam_rt = base2cam * config_.vad2base;
+    Eigen::Matrix4f vad_base2img = viewpad * vad2cam_rt;
 
     // Apply scaling
-    Eigen::Matrix4f lidar2img_scaled = apply_scaling(lidar2img, scale_width, scale_height);
+    Eigen::Matrix4f vad_base2img_scaled = apply_scaling(vad_base2img, scale_width, scale_height);
 
-    std::vector<float> lidar2img_flat = matrix_to_flat(lidar2img_scaled);
+    std::vector<float> vad_base2img_flat = matrix_to_flat(vad_base2img_scaled);
 
-    // Store result at VAD camera ID position after lidar2img calculation
+    // Store result at VAD camera ID position after vad_base2img calculation
     int32_t vad_camera_id = config_.autoware_to_vad_camera_mapping.at(autoware_camera_id);
     if (vad_camera_id >= 0 && vad_camera_id < 6) {
-      std::copy(lidar2img_flat.begin(), lidar2img_flat.end(),
-                frame_lidar2img.begin() + vad_camera_id * 16);
+      std::copy(vad_base2img_flat.begin(), vad_base2img_flat.end(),
+                frame_vad_base2img.begin() + vad_camera_id * 16);
     }
   }
 
-  return frame_lidar2img;
+  return frame_vad_base2img;
 }
 
 } // namespace autoware::tensorrt_vad::vad_interface

--- a/planning/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/planning/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -33,9 +33,9 @@ VadInputData VadInterface::convert_input(const VadInputTopicData & vad_input_top
   float scale_width = config_.target_image_width / static_cast<float>(config_.input_image_width);
   float scale_height = config_.target_image_height / static_cast<float>(config_.input_image_height);
 
-  // Process lidar2img transformation using converter, with caching
+  // Process vad_base2img transformation using converter, with caching
   if (!vad_base2img_transform_.has_value()) {
-    vad_base2img_transform_ = input_transform_matrix_converter_->process_lidar2img(
+    vad_base2img_transform_ = input_transform_matrix_converter_->process_vad_base2img(
       vad_input_topic_data.camera_infos,
       scale_width, scale_height
     );

--- a/planning/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/planning/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -40,7 +40,7 @@ VadInputData VadInterface::convert_input(const VadInputTopicData & vad_input_top
       scale_width, scale_height
     );
   }
-  vad_input_data.lidar2img_ = vad_base2img_transform_.value();
+  vad_input_data.vad_base2img_ = vad_base2img_transform_.value();
   
   // Process can_bus using converter
   vad_input_data.can_bus_ = input_can_bus_converter_->process_can_bus(


### PR DESCRIPTION
## Description

- Rename `lidar2img` to `vad_base2img`
- Rename `lidar2cam` to `vad2cam`
- Rename `viewpad` to `cam2img`

## How was this PR tested?

I checked this PR by launching vad.

<details>
<summary></summary>

```sh
❯ ros2 launch autoware_tensorrt_vad vad.launch.xml use_sim_time:=true
[INFO] [launch]: All log files can be found below /home/shintarotomie/.ros/log/2025-09-03-14-48-11-218292-DPC2305009-3194697
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [vad_node-1]: process started with pid [3194698]
[vad_node-1] [INFO 1756878491.391991590] [vad]: TrtCommon configurations loaded (5GB workspace):
[vad_node-1] [INFO 1756878491.392049334] [vad]:   Backbone - ONNX: /home/shintarotomie/autoware_data/vad/sim_vadv1.extract_img_feat.onnx, Precision: fp16
[vad_node-1] [INFO 1756878491.392056980] [vad]:   Head - ONNX: /home/shintarotomie/autoware_data/vad/sim_vadv1_prev.pts_bbox_head.forward.onnx, Precision: fp32
[vad_node-1] [INFO 1756878491.392063643] [vad]:   Head No Prev - ONNX: /home/shintarotomie/autoware_data/vad/sim_vadv1.pts_bbox_head.forward.onnx, Precision: fp32
[vad_node-1] [INFO 1756878491.676576307] [vad]: Initializing TensorRT engine
[vad_node-1] [INFO 1756878491.676669310] [vad]: Building backbone engine...
[vad_node-1] [I] [TRT] Loaded plugin library: /home/shintarotomie/src/github.com/AutomotiveAIChallenge/aichallenge-2025/aichallenge/workspace/src/e2e-utils-beta/install/autoware_tensorrt_plugins/share/autoware_tensorrt_plugins/plugins/libautoware_tensorrt_plugins.so
[vad_node-1] [I] [TRT] [MemUsageChange] Init CUDA: CPU +0, GPU +0, now: CPU 42, GPU 2359 (MiB)
[vad_node-1] [I] [TRT] [MemUsageChange] Init builder kernel library: CPU +2647, GPU +370, now: CPU 2891, GPU 2754 (MiB)
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Input filename:   /home/shintarotomie/autoware_data/vad/sim_vadv1.extract_img_feat.onnx
[vad_node-1] [I] [TRT] ONNX IR version:  0.0.10
[vad_node-1] [I] [TRT] Opset version:    15
[vad_node-1] [I] [TRT] Producer name:    pytorch
[vad_node-1] [I] [TRT] Producer version: 1.12.0
[vad_node-1] [I] [TRT] Domain:           
[vad_node-1] [I] [TRT] Model version:    0
[vad_node-1] [I] [TRT] Doc string:       
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Loading engine
[vad_node-1] [I] [TRT] Plan was created with TensorRT 10.8.0
[vad_node-1] [I] [TRT] Loaded engine size: 50 MiB
[vad_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +114, now: CPU 0, GPU 160 (MiB)
[vad_node-1] [I] [TRT] Network validation
[vad_node-1] [I] [TRT] Engine setup completed
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [INFO 1756878493.438595314] [vad]: backbone engine built successfully
[vad_node-1] [INFO 1756878493.438643488] [vad]: backbone engine initialization completed successfully
[vad_node-1] [INFO 1756878493.440019057] [vad]: mlvl_feats.0 <- backbone[out.0]
[vad_node-1] [INFO 1756878493.440077177] [vad]: Initializing TensorRT engine
[vad_node-1] [INFO 1756878493.440119234] [vad]: Building head engine...
[vad_node-1] [I] [TRT] Loaded plugin library: /home/shintarotomie/src/github.com/AutomotiveAIChallenge/aichallenge-2025/aichallenge/workspace/src/e2e-utils-beta/install/autoware_tensorrt_plugins/share/autoware_tensorrt_plugins/plugins/libautoware_tensorrt_plugins.so
[vad_node-1] [I] [TRT] The logger passed into createInferRuntime differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] The logger passed into createInferBuilder differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Input filename:   /home/shintarotomie/autoware_data/vad/sim_vadv1_prev.pts_bbox_head.forward.onnx
[vad_node-1] [I] [TRT] ONNX IR version:  0.0.10
[vad_node-1] [I] [TRT] Opset version:    15
[vad_node-1] [I] [TRT] Producer name:    pytorch
[vad_node-1] [I] [TRT] Producer version: 1.12.0
[vad_node-1] [I] [TRT] Domain:           
[vad_node-1] [I] [TRT] Model version:    0
[vad_node-1] [I] [TRT] Doc string:       
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] No checker registered for op: RotatePlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: RotatePlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: RotatePlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: RotatePlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] Loading engine
[vad_node-1] [I] [TRT] Plan was created with TensorRT 10.8.0
[vad_node-1] [I] [TRT] Loaded engine size: 96 MiB
[vad_node-1] [I] [TRT] [MS] Running engine with multi stream info
[vad_node-1] [I] [TRT] [MS] Number of aux streams is 7
[vad_node-1] [I] [TRT] [MS] Number of total worker streams is 8
[vad_node-1] [I] [TRT] [MS] The main stream provided by execute/enqueue calls is the first worker stream
[vad_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +607, now: CPU 0, GPU 852 (MiB)
[vad_node-1] [I] [TRT] Network validation
[vad_node-1] [I] [TRT] Engine setup completed
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [INFO 1756878493.828762190] [vad]: head engine built successfully
[vad_node-1] [INFO 1756878493.828797460] [vad]: head engine initialization completed successfully
[vad_node-1] [INFO 1756878493.828883532] [vad]: mlvl_feats.0 <- backbone[out.0]
[vad_node-1] [INFO 1756878493.828902472] [vad]: Initializing TensorRT engine
[vad_node-1] [INFO 1756878493.828919877] [vad]: Building head_no_prev engine...
[vad_node-1] [I] [TRT] Loaded plugin library: /home/shintarotomie/src/github.com/AutomotiveAIChallenge/aichallenge-2025/aichallenge/workspace/src/e2e-utils-beta/install/autoware_tensorrt_plugins/share/autoware_tensorrt_plugins/plugins/libautoware_tensorrt_plugins.so
[vad_node-1] [I] [TRT] The logger passed into createInferRuntime differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] The logger passed into createInferBuilder differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Input filename:   /home/shintarotomie/autoware_data/vad/sim_vadv1.pts_bbox_head.forward.onnx
[vad_node-1] [I] [TRT] ONNX IR version:  0.0.10
[vad_node-1] [I] [TRT] Opset version:    15
[vad_node-1] [I] [TRT] Producer name:    pytorch
[vad_node-1] [I] [TRT] Producer version: 1.12.0
[vad_node-1] [I] [TRT] Domain:           
[vad_node-1] [I] [TRT] Model version:    0
[vad_node-1] [I] [TRT] Doc string:       
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] Loading engine
[vad_node-1] [I] [TRT] Plan was created with TensorRT 10.8.0
[vad_node-1] [I] [TRT] Loaded engine size: 97 MiB
[vad_node-1] [I] [TRT] [MS] Running engine with multi stream info
[vad_node-1] [I] [TRT] [MS] Number of aux streams is 7
[vad_node-1] [I] [TRT] [MS] Number of total worker streams is 8
[vad_node-1] [I] [TRT] [MS] The main stream provided by execute/enqueue calls is the first worker stream
[vad_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +580, now: CPU 0, GPU 1516 (MiB)
[vad_node-1] [I] [TRT] Network validation
[vad_node-1] [I] [TRT] Engine setup completed
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [INFO 1756878494.209796615] [vad]: head_no_prev engine built successfully
[vad_node-1] [INFO 1756878494.209834313] [vad]: head_no_prev engine initialization completed successfully
[vad_node-1] [INFO 1756878494.210097596] [vad]: VAD model and interface initialized successfully
[vad_node-1] [INFO 1756878494.210153663] [vad]: VAD Node has been initialized - VAD model will be initialized after first callback
[vad_node-1] [ERROR 1756878507.522197308] [vad]: Synchronization strategy indicates data is not ready for inference
[vad_node-1] [INFO 1756878508.361130534] [vad]: mlvl_feats.0 <- backbone[out.0]

```

</details>

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
