### PR TITLE
feat(autoware_tensorrt_vad): use double in map coordinate because float is not enough for map coodinate.

### DIFF
--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/output_converter/map_converter.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/output_converter/map_converter.hpp
@@ -38,7 +38,7 @@ public:
   visualization_msgs::msg::MarkerArray process_map_points(
     const std::vector<MapPolyline>& vad_map_polylines,
     const rclcpp::Time& stamp,
-    const Eigen::Matrix4f& base2map_transform) const;
+    const Eigen::Matrix4d& base2map_transform) const;
 
 private:
   /**
@@ -53,7 +53,7 @@ private:
     const MapPolyline& map_polyline,
     const int32_t marker_id,
     const rclcpp::Time& stamp,
-    const Eigen::Matrix4f& base2map_transform) const;
+    const Eigen::Matrix4d& base2map_transform) const;
 
   /**
    * @brief Get color for a specific map type

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/output_converter/objects_converter.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/output_converter/objects_converter.hpp
@@ -41,7 +41,7 @@ public:
   autoware_perception_msgs::msg::PredictedObjects process_predicted_objects(
     const std::vector<BBox>& bboxes,
     const rclcpp::Time& stamp,
-    const Eigen::Matrix4f& base2map_transform) const;
+    const Eigen::Matrix4d& base2map_transform) const;
 
 private:
   // TODO(Shin-kyoto): tentative implementation. 
@@ -84,7 +84,7 @@ private:
    */
   std::vector<autoware_perception_msgs::msg::PredictedPath> convert_predicted_paths(
     const BBox& bbox,
-    const Eigen::Matrix4f& base2map_transform,
+    const Eigen::Matrix4d& base2map_transform,
     const float yaw) const;
 
   /**
@@ -95,7 +95,7 @@ private:
    */
   geometry_msgs::msg::Point convert_position(
     const BBox& bbox,
-    const Eigen::Matrix4f& base2map_transform) const;
+    const Eigen::Matrix4d& base2map_transform) const;
 
   /**
    * @brief Calculate object orientation from trajectory or bbox
@@ -105,7 +105,7 @@ private:
    */
   float calculate_object_orientation(
     const BBox& bbox,
-    const Eigen::Matrix4f& base2map_transform) const;
+    const Eigen::Matrix4d& base2map_transform) const;
 
   /**
    * @brief Calculate predicted path yaw
@@ -115,7 +115,7 @@ private:
    */
    std::optional<float> calculate_predicted_path_yaw(
     const BBox& bbox,
-    const Eigen::Matrix4f& base2map_transform) const;
+    const Eigen::Matrix4d& base2map_transform) const;
 
   };
 

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/output_converter/trajectory_converter.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/output_converter/trajectory_converter.hpp
@@ -46,7 +46,7 @@ public:
     const std::vector<float>& predicted_trajectory,
     const rclcpp::Time& stamp,
     const double trajectory_timestep,
-    const Eigen::Matrix4f& base2map_transform) const;
+    const Eigen::Matrix4d& base2map_transform) const;
 
   /**
    * @brief Convert VAD candidate trajectories to ROS CandidateTrajectories message
@@ -60,7 +60,7 @@ public:
     const std::map<int32_t, std::vector<float>>& predicted_trajectories,
     const rclcpp::Time& stamp,
     const double trajectory_timestep,
-    const Eigen::Matrix4f& base2map_transform) const;
+    const Eigen::Matrix4d& base2map_transform) const;
 
 private:
   /**
@@ -73,7 +73,7 @@ private:
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> create_trajectory_points(
     const std::vector<float>& predicted_trajectory,
     const double trajectory_timestep,
-    const Eigen::Matrix4f& base2map_transform) const;
+    const Eigen::Matrix4d& base2map_transform) const;
 };
 
 } // namespace autoware::tensorrt_vad::vad_interface

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_interface.hpp
@@ -135,7 +135,7 @@ public:
     const VadOutputData & vad_output_data, 
     const rclcpp::Time & stamp,
     const double trajectory_timestep,
-    const Eigen::Matrix4f & base2map_transform) const;
+    const Eigen::Matrix4d & base2map_transform) const;
 
 
 private:

--- a/planning/autoware_tensorrt_vad/lib/output_converter/map_converter.cpp
+++ b/planning/autoware_tensorrt_vad/lib/output_converter/map_converter.cpp
@@ -22,7 +22,7 @@ visualization_msgs::msg::Marker OutputMapConverter::create_polyline_marker(
   const MapPolyline& map_polyline,
   const int32_t marker_id,
   const rclcpp::Time& stamp,
-  const Eigen::Matrix4f& base2map_transform) const
+  const Eigen::Matrix4d& base2map_transform) const
 {
   visualization_msgs::msg::Marker marker;
   
@@ -53,8 +53,8 @@ visualization_msgs::msg::Marker OutputMapConverter::create_polyline_marker(
       
       auto [aw_x, aw_y, aw_z] = coordinate_transformer_.vad2aw_xyz(vad_x, vad_y, 0.0f);
       
-      Eigen::Vector4f base_point(aw_x, aw_y, 0.0f, 1.0f);
-      Eigen::Vector4f map_point = base2map_transform * base_point;
+      Eigen::Vector4d base_point(static_cast<double>(aw_x), static_cast<double>(aw_y), 0.0, 1.0);
+      Eigen::Vector4d map_point = base2map_transform * base_point;
       
       geometry_msgs::msg::Point geometry_point;
       geometry_point.x = map_point[0];
@@ -81,7 +81,7 @@ visualization_msgs::msg::Marker OutputMapConverter::create_polyline_marker(
 visualization_msgs::msg::MarkerArray OutputMapConverter::process_map_points(
   const std::vector<MapPolyline>& vad_map_polylines,
   const rclcpp::Time& stamp,
-  const Eigen::Matrix4f& base2map_transform) const
+  const Eigen::Matrix4d& base2map_transform) const
 {
   visualization_msgs::msg::MarkerArray marker_array;
 

--- a/planning/autoware_tensorrt_vad/lib/output_converter/trajectory_converter.cpp
+++ b/planning/autoware_tensorrt_vad/lib/output_converter/trajectory_converter.cpp
@@ -12,20 +12,20 @@ OutputTrajectoryConverter::OutputTrajectoryConverter(const CoordinateTransformer
 std::vector<autoware_planning_msgs::msg::TrajectoryPoint> OutputTrajectoryConverter::create_trajectory_points(
   const std::vector<float>& predicted_trajectory,
   const double trajectory_timestep,
-  const Eigen::Matrix4f& base2map_transform) const
+  const Eigen::Matrix4d& base2map_transform) const
 {
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points;
   
   // function to transform direction vector from base coordinate system to map coordinate system
   auto transform_direction_to_map = [&base2map_transform](const float base_dx, const float base_dy) -> float {
-    Eigen::Vector3f base_direction(base_dx, base_dy, 0.0f);
-    Eigen::Vector3f map_direction = base2map_transform.block<3, 3>(0, 0) * base_direction;
+    Eigen::Vector3d base_direction(static_cast<double>(base_dx), static_cast<double>(base_dy), 0.0);
+    Eigen::Vector3d map_direction = base2map_transform.block<3, 3>(0, 0) * base_direction;
     return std::atan2(map_direction.y(), map_direction.x());
   };
   
   // Add 0-second point (0,0)
   autoware_planning_msgs::msg::TrajectoryPoint initial_point;
-  Eigen::Vector4f init_ego_position = base2map_transform * Eigen::Vector4f(0.0, 0.0, 0.0, 1.0);
+  Eigen::Vector4d init_ego_position = base2map_transform * Eigen::Vector4d(0.0, 0.0, 0.0, 1.0);
   initial_point.pose.position.x = init_ego_position[0];
   initial_point.pose.position.y = init_ego_position[1];
   initial_point.pose.position.z = init_ego_position[2];
@@ -50,8 +50,8 @@ std::vector<autoware_planning_msgs::msg::TrajectoryPoint> OutputTrajectoryConver
     float vad_y = predicted_trajectory[i + 1];
 
     auto [aw_x, aw_y, aw_z] = coordinate_transformer_.vad2aw_xyz(vad_x, vad_y, 0.0f);
-    Eigen::Vector4f base_link_position(aw_x, aw_y, 0.0, 1.0);
-    Eigen::Vector4f map_position = base2map_transform * base_link_position;
+    Eigen::Vector4d base_link_position(static_cast<double>(aw_x), static_cast<double>(aw_y), 0.0, 1.0);
+    Eigen::Vector4d map_position = base2map_transform * base_link_position;
 
     point.pose.position.x = map_position[0];
     point.pose.position.y = map_position[1];
@@ -97,7 +97,7 @@ autoware_internal_planning_msgs::msg::CandidateTrajectories OutputTrajectoryConv
   const std::map<int32_t, std::vector<float>>& predicted_trajectories,
   const rclcpp::Time& stamp,
   const double trajectory_timestep,
-  const Eigen::Matrix4f& base2map_transform) const
+  const Eigen::Matrix4d& base2map_transform) const
 {
   autoware_internal_planning_msgs::msg::CandidateTrajectories candidate_trajectories_msg;
 
@@ -130,7 +130,7 @@ autoware_planning_msgs::msg::Trajectory OutputTrajectoryConverter::process_traje
   const std::vector<float>& predicted_trajectory,
   const rclcpp::Time& stamp,
   const double trajectory_timestep,
-  const Eigen::Matrix4f& base2map_transform) const
+  const Eigen::Matrix4d& base2map_transform) const
 {
   autoware_planning_msgs::msg::Trajectory trajectory_msg;
 

--- a/planning/autoware_tensorrt_vad/lib/vad_interface.cpp
+++ b/planning/autoware_tensorrt_vad/lib/vad_interface.cpp
@@ -68,7 +68,7 @@ VadOutputTopicData VadInterface::convert_output(
   const VadOutputData & vad_output_data,
   const rclcpp::Time & stamp,
   const double trajectory_timestep,
-  const Eigen::Matrix4f & base2map_transform) const
+  const Eigen::Matrix4d & base2map_transform) const
 {
   VadOutputTopicData output_topic_data;
 

--- a/planning/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/planning/autoware_tensorrt_vad/src/vad_node.cpp
@@ -21,7 +21,7 @@
 
 namespace autoware::tensorrt_vad
 {
-std::pair<Eigen::Matrix4f, Eigen::Matrix4f> get_transform_matrix(
+std::pair<Eigen::Matrix4d, Eigen::Matrix4d> get_transform_matrix(
   const nav_msgs::msg::Odometry & msg)
 {
   // Extract position
@@ -30,31 +30,31 @@ std::pair<Eigen::Matrix4f, Eigen::Matrix4f> get_transform_matrix(
   double z = msg.pose.pose.position.z;
 
   // Create Eigen quaternion and normalize it
-  Eigen::Quaternionf q = std::invoke([&msg]() -> Eigen::Quaternionf {
+  Eigen::Quaterniond q = std::invoke([&msg]() -> Eigen::Quaterniond {
     double qx = msg.pose.pose.orientation.x;
     double qy = msg.pose.pose.orientation.y;
     double qz = msg.pose.pose.orientation.z;
     double qw = msg.pose.pose.orientation.w;
 
     // Create Eigen quaternion and normalize it
-    Eigen::Quaternionf q(qw, qx, qy, qz);
-    return (q.norm() < std::numeric_limits<float>::epsilon()) ? Eigen::Quaternionf::Identity()
-                                                              : q.normalized();
+    Eigen::Quaterniond q(qw, qx, qy, qz);
+    return (q.norm() < std::numeric_limits<double>::epsilon()) ? Eigen::Quaterniond::Identity()
+                                                               : q.normalized();
   });
 
   // Rotation matrix (3x3)
-  Eigen::Matrix3f R = q.toRotationMatrix();
+  Eigen::Matrix3d R = q.toRotationMatrix();
 
   // Translation vector
-  Eigen::Vector3f t(x, y, z);
+  Eigen::Vector3d t(x, y, z);
 
   // Base_link → Map (forward)
-  Eigen::Matrix4f bl2map = Eigen::Matrix4f::Identity();
+  Eigen::Matrix4d bl2map = Eigen::Matrix4d::Identity();
   bl2map.block<3, 3>(0, 0) = R;
   bl2map.block<3, 1>(0, 3) = t;
 
   // Map → Base_link (inverse)
-  Eigen::Matrix4f map2bl = Eigen::Matrix4f::Identity();
+  Eigen::Matrix4d map2bl = Eigen::Matrix4d::Identity();
   map2bl.block<3, 3>(0, 0) = R.transpose();
   map2bl.block<3, 1>(0, 3) = -R.transpose() * t;
 


### PR DESCRIPTION
## Description

- Change `float`  to `double` in code to process trajectory, map and object because float is not enough for map coodinate.

## Related links

None.

## How was this PR tested?

<details>
<summary></summary>
❯ ros2 launch autoware_tensorrt_vad vad.launch.xml use_sim_time:=true
[INFO] [launch]: All log files can be found below /home/shintarotomie/.ros/log/2025-09-04-10-39-19-217594-DPC2305009-3886452
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [vad_node-1]: process started with pid [3886453]
[vad_node-1] [INFO 1756949959.380000530] [vad]: TrtCommon configurations loaded (5GB workspace):
[vad_node-1] [INFO 1756949959.380360637] [vad]:   Backbone - ONNX: /home/shintarotomie/autoware_data/vad/sim_vadv1.extract_img_feat.onnx, Precision: fp16
[vad_node-1] [INFO 1756949959.380489356] [vad]:   Head - ONNX: /home/shintarotomie/autoware_data/vad/sim_vadv1_prev.pts_bbox_head.forward.onnx, Precision: fp32
[vad_node-1] [INFO 1756949959.380588480] [vad]:   Head No Prev - ONNX: /home/shintarotomie/autoware_data/vad/sim_vadv1.pts_bbox_head.forward.onnx, Precision: fp32
[vad_node-1] [INFO 1756949959.665166408] [vad]: Initializing TensorRT engine
[vad_node-1] [INFO 1756949959.665255218] [vad]: Building backbone engine...
[vad_node-1] [I] [TRT] Loaded plugin library: /home/shintarotomie/src/github.com/AutomotiveAIChallenge/aichallenge-2025/aichallenge/workspace/src/e2e-utils-beta/install/autoware_tensorrt_plugins/share/autoware_tensorrt_plugins/plugins/libautoware_tensorrt_plugins.so
[vad_node-1] [I] [TRT] [MemUsageChange] Init CUDA: CPU +0, GPU +0, now: CPU 42, GPU 2182 (MiB)
[vad_node-1] [I] [TRT] [MemUsageChange] Init builder kernel library: CPU +2647, GPU +337, now: CPU 2891, GPU 2551 (MiB)
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Input filename:   /home/shintarotomie/autoware_data/vad/sim_vadv1.extract_img_feat.onnx
[vad_node-1] [I] [TRT] ONNX IR version:  0.0.10
[vad_node-1] [I] [TRT] Opset version:    15
[vad_node-1] [I] [TRT] Producer name:    pytorch
[vad_node-1] [I] [TRT] Producer version: 1.12.0
[vad_node-1] [I] [TRT] Domain:           
[vad_node-1] [I] [TRT] Model version:    0
[vad_node-1] [I] [TRT] Doc string:       
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Loading engine
[vad_node-1] [I] [TRT] Plan was created with TensorRT 10.8.0
[vad_node-1] [I] [TRT] Loaded engine size: 50 MiB
[vad_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +114, now: CPU 0, GPU 160 (MiB)
[vad_node-1] [I] [TRT] Network validation
[vad_node-1] [I] [TRT] Engine setup completed
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [INFO 1756949961.328998610] [vad]: backbone engine built successfully
[vad_node-1] [INFO 1756949961.329041937] [vad]: backbone engine initialization completed successfully
[vad_node-1] [INFO 1756949961.330414246] [vad]: mlvl_feats.0 <- backbone[out.0]
[vad_node-1] [INFO 1756949961.330458191] [vad]: Initializing TensorRT engine
[vad_node-1] [INFO 1756949961.330499947] [vad]: Building head engine...
[vad_node-1] [I] [TRT] Loaded plugin library: /home/shintarotomie/src/github.com/AutomotiveAIChallenge/aichallenge-2025/aichallenge/workspace/src/e2e-utils-beta/install/autoware_tensorrt_plugins/share/autoware_tensorrt_plugins/plugins/libautoware_tensorrt_plugins.so
[vad_node-1] [I] [TRT] The logger passed into createInferRuntime differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] The logger passed into createInferBuilder differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Input filename:   /home/shintarotomie/autoware_data/vad/sim_vadv1_prev.pts_bbox_head.forward.onnx
[vad_node-1] [I] [TRT] ONNX IR version:  0.0.10
[vad_node-1] [I] [TRT] Opset version:    15
[vad_node-1] [I] [TRT] Producer name:    pytorch
[vad_node-1] [I] [TRT] Producer version: 1.12.0
[vad_node-1] [I] [TRT] Domain:           
[vad_node-1] [I] [TRT] Model version:    0
[vad_node-1] [I] [TRT] Doc string:       
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] No checker registered for op: RotatePlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: RotatePlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: RotatePlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: RotatePlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] Loading engine
[vad_node-1] [I] [TRT] Plan was created with TensorRT 10.8.0
[vad_node-1] [I] [TRT] Loaded engine size: 96 MiB
[vad_node-1] [I] [TRT] [MS] Running engine with multi stream info
[vad_node-1] [I] [TRT] [MS] Number of aux streams is 7
[vad_node-1] [I] [TRT] [MS] Number of total worker streams is 8
[vad_node-1] [I] [TRT] [MS] The main stream provided by execute/enqueue calls is the first worker stream
[vad_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +607, now: CPU 0, GPU 852 (MiB)
[vad_node-1] [I] [TRT] Network validation
[vad_node-1] [I] [TRT] Engine setup completed
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [INFO 1756949961.694981336] [vad]: head engine built successfully
[vad_node-1] [INFO 1756949961.695017463] [vad]: head engine initialization completed successfully
[vad_node-1] [INFO 1756949961.695105745] [vad]: mlvl_feats.0 <- backbone[out.0]
[vad_node-1] [INFO 1756949961.695123941] [vad]: Initializing TensorRT engine
[vad_node-1] [INFO 1756949961.695153662] [vad]: Building head_no_prev engine...
[vad_node-1] [I] [TRT] Loaded plugin library: /home/shintarotomie/src/github.com/AutomotiveAIChallenge/aichallenge-2025/aichallenge/workspace/src/e2e-utils-beta/install/autoware_tensorrt_plugins/share/autoware_tensorrt_plugins/plugins/libautoware_tensorrt_plugins.so
[vad_node-1] [I] [TRT] The logger passed into createInferRuntime differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] The logger passed into createInferBuilder differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Input filename:   /home/shintarotomie/autoware_data/vad/sim_vadv1.pts_bbox_head.forward.onnx
[vad_node-1] [I] [TRT] ONNX IR version:  0.0.10
[vad_node-1] [I] [TRT] Opset version:    15
[vad_node-1] [I] [TRT] Producer name:    pytorch
[vad_node-1] [I] [TRT] Producer version: 1.12.0
[vad_node-1] [I] [TRT] Domain:           
[vad_node-1] [I] [TRT] Model version:    0
[vad_node-1] [I] [TRT] Doc string:       
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] Loading engine
[vad_node-1] [I] [TRT] Plan was created with TensorRT 10.8.0
[vad_node-1] [I] [TRT] Loaded engine size: 97 MiB
[vad_node-1] [I] [TRT] [MS] Running engine with multi stream info
[vad_node-1] [I] [TRT] [MS] Number of aux streams is 7
[vad_node-1] [I] [TRT] [MS] Number of total worker streams is 8
[vad_node-1] [I] [TRT] [MS] The main stream provided by execute/enqueue calls is the first worker stream
[vad_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +580, now: CPU 0, GPU 1516 (MiB)
[vad_node-1] [I] [TRT] Network validation
[vad_node-1] [I] [TRT] Engine setup completed
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [INFO 1756949962.065216534] [vad]: head_no_prev engine built successfully
[vad_node-1] [INFO 1756949962.065255880] [vad]: head_no_prev engine initialization completed successfully
[vad_node-1] [INFO 1756949962.065509871] [vad]: VAD model and interface initialized successfully
[vad_node-1] [INFO 1756949962.065583714] [vad]: VAD Node has been initialized - VAD model will be initialized after first callback
[vad_node-1] [ERROR 1756949970.122538958] [vad]: Synchronization strategy indicates data is not ready for inference
[vad_node-1] [INFO 1756949970.959881753] [vad]: mlvl_feats.0 <- backbone[out.0]

</details>

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
