### PR TITLE
refactor(autoware_tensorrt_vad): use cuda in image preprocess

### DIFF
--- a/planning/autoware_tensorrt_vad/CMakeLists.txt
+++ b/planning/autoware_tensorrt_vad/CMakeLists.txt
@@ -3,9 +3,14 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_tensorrt_vad)
 
 find_package(autoware_cmake REQUIRED)
+
+# Disable strict compilation flags that interfere with CUDA
+set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
+
 autoware_package(
     SKIP_LINT
-  )
+    SKIP_BUILD_WARNINGS
+)
 
 # Set C++17 standard to match Autoware Universe
 if(NOT CMAKE_CXX_STANDARD)
@@ -13,8 +18,6 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-add_compile_options(-Wno-deprecated-declarations)
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
@@ -36,9 +39,22 @@ else()
     set(TENSORRT_LIBRARY_DIRS /usr/lib/x86_64-linux-gnu)
 endif()
 
+# Enable CUDA language
+enable_language(CUDA)
+
 # CUDA settings
 set(CUDA_INCLUDE_DIRS ${CUDA_TOOLKIT_ROOT_DIR}/include)
 set(CUDA_LIBRARY_DIRS ${CUDA_TOOLKIT_ROOT_DIR}/lib64)
+
+# Set CUDA architecture
+set(CMAKE_CUDA_ARCHITECTURES 75 80 86)
+set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
+
+# Separate compile options for C++ and CUDA
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+
+# Explicitly disable Werror for CUDA
+set(CMAKE_CUDA_FLAGS "")
 
 # Include directory settings
 include_directories(
@@ -46,6 +62,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/lib
     ${CUDA_INCLUDE_DIRS}
     ${TENSORRT_INCLUDE_DIRS}
+    ${OpenCV_INCLUDE_DIRS}
 )
 
 # Link directory settings
@@ -54,10 +71,56 @@ link_directories(
     ${TENSORRT_LIBRARY_DIRS}
 )
 
-# Add main library (excluding header files)
+# Compile CUDA kernel separately
+set_source_files_properties(
+    lib/networks/preprocess/multi_camera_preprocess_kernel.cu
+    PROPERTIES 
+    LANGUAGE CUDA
+    COMPILE_FLAGS "-w"
+)
+
+# Create separate CUDA library to isolate compilation issues
+add_library(${PROJECT_NAME}_cuda_lib STATIC
+    lib/networks/preprocess/multi_camera_preprocess_kernel.cu
+)
+
+set_target_properties(${PROJECT_NAME}_cuda_lib PROPERTIES
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    POSITION_INDEPENDENT_CODE ON
+    CUDA_RUNTIME_LIBRARY Shared
+    CUDA_STANDARD 17
+    CUDA_STANDARD_REQUIRED ON
+)
+
+target_include_directories(${PROJECT_NAME}_cuda_lib PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib
+    ${CUDA_INCLUDE_DIRS}
+    ${TENSORRT_INCLUDE_DIRS}
+    ${OpenCV_INCLUDE_DIRS}
+)
+
+# Link OpenCV to CUDA library if needed
+target_link_libraries(${PROJECT_NAME}_cuda_lib PRIVATE
+    ${OpenCV_LIBS}
+)
+
+# Override all inherited compile options for CUDA library
+set_target_properties(${PROJECT_NAME}_cuda_lib PROPERTIES
+    COMPILE_OPTIONS ""
+    COMPILE_FLAGS ""
+)
+
+# Set minimal CUDA-specific compile options
+target_compile_options(${PROJECT_NAME}_cuda_lib PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:-w>
+)
+
+# Add main library (excluding CUDA files)
 ament_auto_add_library(${PROJECT_NAME}_lib SHARED
     lib/vad_interface.cpp
     lib/vad_model.cpp
+    lib/vad_config.cpp
     lib/synchronization_strategy.cpp
     lib/coordinate_transformer.cpp
     lib/converter.cpp
@@ -72,10 +135,17 @@ ament_auto_add_library(${PROJECT_NAME}_lib SHARED
     lib/networks/backbone.cpp
     lib/networks/head.cpp
     lib/networks/tensor.cpp
+    lib/networks/preprocess/multi_camera_preprocess.cpp
+)
+
+# Set properties for the main library
+set_target_properties(${PROJECT_NAME}_lib PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
 )
 
 # Library link settings
 target_link_libraries(${PROJECT_NAME}_lib
+    ${PROJECT_NAME}_cuda_lib
     nvinfer
     ${CUDA_LIBRARIES}
     cuda
@@ -98,6 +168,7 @@ rclcpp_components_register_node(${PROJECT_NAME}_component
 )
 
 ament_auto_package(
+    USE_SCOPED_HEADER_INSTALL_DIR
     INSTALL_TO_SHARE
         launch
         config

--- a/planning/autoware_tensorrt_vad/CMakeLists.txt
+++ b/planning/autoware_tensorrt_vad/CMakeLists.txt
@@ -45,12 +45,6 @@ set(CUDA_LIBRARY_DIRS ${CUDA_TOOLKIT_ROOT_DIR}/lib64)
 set(CMAKE_CUDA_ARCHITECTURES 75 80 86)
 set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
 
-# Separate compile options for C++ and CUDA
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
-
-# Explicitly disable Werror for CUDA
-set(CMAKE_CUDA_FLAGS "")
-
 # Include directory settings
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/planning/autoware_tensorrt_vad/CMakeLists.txt
+++ b/planning/autoware_tensorrt_vad/CMakeLists.txt
@@ -4,12 +4,8 @@ project(autoware_tensorrt_vad)
 
 find_package(autoware_cmake REQUIRED)
 
-# Disable strict compilation flags that interfere with CUDA
-set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
-
 autoware_package(
     SKIP_LINT
-    SKIP_BUILD_WARNINGS
 )
 
 # Set C++17 standard to match Autoware Universe

--- a/planning/autoware_tensorrt_vad/CMakeLists.txt
+++ b/planning/autoware_tensorrt_vad/CMakeLists.txt
@@ -3,110 +3,80 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_tensorrt_vad)
 
 find_package(autoware_cmake REQUIRED)
-autoware_package(
-    SKIP_LINT
-)
+autoware_package()
 
-# Set C++17 standard to match Autoware Universe
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+add_compile_options(-Wno-deprecated-declarations)
 
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
 
-# Find additional dependencies for components
-find_package(CUDA REQUIRED)
-find_package(eigen3_cmake_module REQUIRED)
-find_package(Eigen3 REQUIRED)
-find_package(OpenCV REQUIRED)
-
-# TensorRT settings
-option(TRT_ROOT "$ENV{TRT_ROOT}")
-if(TRT_ROOT)
-    set(TENSORRT_INCLUDE_DIRS ${TRT_ROOT}/include/)
-    set(TENSORRT_LIBRARY_DIRS ${TRT_ROOT}/lib/)
+# set flags for CUDA availability
+option(CUDA_AVAIL "CUDA available" OFF)
+find_package(CUDA)
+if(CUDA_FOUND)
+  find_library(CUBLAS_LIBRARIES cublas HINTS
+    ${CUDA_TOOLKIT_ROOT_DIR}/lib64
+    ${CUDA_TOOLKIT_ROOT_DIR}/lib
+  )
+  if(CUDA_VERBOSE)
+    message("CUDA is available!")
+    message("CUDA Libs: ${CUDA_LIBRARIES}")
+    message("CUDA Headers: ${CUDA_INCLUDE_DIRS}")
+  endif()
+  set(CUDA_AVAIL ON)
 else()
-    # Default TensorRT paths
-    set(TENSORRT_INCLUDE_DIRS /usr/include/x86_64-linux-gnu)
-    set(TENSORRT_LIBRARY_DIRS /usr/lib/x86_64-linux-gnu)
+  message("CUDA NOT FOUND")
+  set(CUDA_AVAIL OFF)
 endif()
 
-# Enable CUDA language
-enable_language(CUDA)
+# set flags for TensorRT availability
+option(TRT_AVAIL "TensorRT available" OFF)
+# try to find the tensorRT modules
+find_library(NVINFER nvinfer)
+find_library(NVONNXPARSER nvonnxparser)
+if(NVINFER AND NVONNXPARSER)
+  if(CUDA_VERBOSE)
+    message("TensorRT is available!")
+    message("NVINFER: ${NVINFER}")
+    message("NVONNXPARSER: ${NVONNXPARSER}")
+  endif()
+  set(TRT_AVAIL ON)
+else()
+  message("TensorRT is NOT available")
+  set(TRT_AVAIL OFF)
+endif()
 
-# CUDA settings
-set(CUDA_INCLUDE_DIRS ${CUDA_TOOLKIT_ROOT_DIR}/include)
-set(CUDA_LIBRARY_DIRS ${CUDA_TOOLKIT_ROOT_DIR}/lib64)
+if(TRT_AVAIL AND CUDA_AVAIL)
+  find_package(ament_cmake_auto REQUIRED)
+  ament_auto_find_build_dependencies()
 
-# Set CUDA architecture
-set(CMAKE_CUDA_ARCHITECTURES 75 80 86)
-set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
+  # Find additional dependencies
+  find_package(eigen3_cmake_module REQUIRED)
+  find_package(Eigen3 REQUIRED)
+  find_package(OpenCV REQUIRED)
 
-# Include directory settings
-include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/lib
+  include_directories(
+    include
     ${CUDA_INCLUDE_DIRS}
-    ${TENSORRT_INCLUDE_DIRS}
-    ${OpenCV_INCLUDE_DIRS}
-)
+  )
 
-# Link directory settings
-link_directories(
-    ${CUDA_LIBRARY_DIRS}
-    ${TENSORRT_LIBRARY_DIRS}
-)
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_CUDA_FLAGS ${CMAKE_CUDA_FLAGS} "-g -G")
+  endif()
 
-# Compile CUDA kernel separately
-set_source_files_properties(
+  # CUDA architecture settings
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_80,code=sm_80")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
+
+  cuda_add_library(${PROJECT_NAME}_cuda_lib SHARED
     lib/networks/preprocess/multi_camera_preprocess_kernel.cu
-    PROPERTIES 
-    LANGUAGE CUDA
-    COMPILE_FLAGS "-w"
-)
+  )
 
-# Create separate CUDA library to isolate compilation issues
-add_library(${PROJECT_NAME}_cuda_lib STATIC
-    lib/networks/preprocess/multi_camera_preprocess_kernel.cu
-)
-
-set_target_properties(${PROJECT_NAME}_cuda_lib PROPERTIES
-    CUDA_RESOLVE_DEVICE_SYMBOLS ON
-    POSITION_INDEPENDENT_CODE ON
-    CUDA_RUNTIME_LIBRARY Shared
-    CUDA_STANDARD 17
-    CUDA_STANDARD_REQUIRED ON
-)
-
-target_include_directories(${PROJECT_NAME}_cuda_lib PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/lib
-    ${CUDA_INCLUDE_DIRS}
-    ${TENSORRT_INCLUDE_DIRS}
-    ${OpenCV_INCLUDE_DIRS}
-)
-
-# Link OpenCV to CUDA library if needed
-target_link_libraries(${PROJECT_NAME}_cuda_lib PRIVATE
+  target_link_libraries(${PROJECT_NAME}_cuda_lib
     ${OpenCV_LIBS}
-)
+  )
 
-# Override all inherited compile options for CUDA library
-set_target_properties(${PROJECT_NAME}_cuda_lib PROPERTIES
-    COMPILE_OPTIONS ""
-    COMPILE_FLAGS ""
-)
-
-# Set minimal CUDA-specific compile options
-target_compile_options(${PROJECT_NAME}_cuda_lib PRIVATE
-    $<$<COMPILE_LANGUAGE:CUDA>:-w>
-)
-
-# Add main library (excluding CUDA files)
-ament_auto_add_library(${PROJECT_NAME}_lib SHARED
+  ament_auto_add_library(${PROJECT_NAME}_lib SHARED
     lib/vad_interface.cpp
     lib/vad_model.cpp
     lib/vad_config.cpp
@@ -125,40 +95,54 @@ ament_auto_add_library(${PROJECT_NAME}_lib SHARED
     lib/networks/head.cpp
     lib/networks/tensor.cpp
     lib/networks/preprocess/multi_camera_preprocess.cpp
-)
+  )
 
-# Set properties for the main library
-set_target_properties(${PROJECT_NAME}_lib PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
-)
-
-# Library link settings
-target_link_libraries(${PROJECT_NAME}_lib
-    ${PROJECT_NAME}_cuda_lib
-    nvinfer
+  target_link_libraries(${PROJECT_NAME}_lib
+    ${NVINFER}
+    ${NVONNXPARSER}
     ${CUDA_LIBRARIES}
-    cuda
-    cudart
+    ${CUBLAS_LIBRARIES}
     ${OpenCV_LIBS}
-)
+    ${PROJECT_NAME}_cuda_lib
+  )
 
-# Add component
-ament_auto_add_library(${PROJECT_NAME}_component SHARED
+  target_include_directories(${PROJECT_NAME}_lib
+    SYSTEM PUBLIC
+    ${CUDA_INCLUDE_DIRS}
+  )
+
+  ament_auto_add_library(${PROJECT_NAME}_component SHARED
     src/vad_node.cpp
-)
+  )
 
-target_link_libraries(${PROJECT_NAME}_component
+  target_link_libraries(${PROJECT_NAME}_component
     ${PROJECT_NAME}_lib
-)
+  )
 
-rclcpp_components_register_node(${PROJECT_NAME}_component
+  rclcpp_components_register_node(${PROJECT_NAME}_component
     PLUGIN "autoware::tensorrt_vad::VadNode"
     EXECUTABLE vad_node
-)
+  )
 
-ament_auto_package(
+  install(
+    TARGETS ${PROJECT_NAME}_cuda_lib
+    DESTINATION lib
+  )
+
+  ament_auto_package(
     USE_SCOPED_HEADER_INSTALL_DIR
     INSTALL_TO_SHARE
         launch
         config
-)
+  )
+
+else()
+  find_package(ament_cmake_auto REQUIRED)
+  ament_auto_find_build_dependencies()
+
+  ament_auto_package(
+    INSTALL_TO_SHARE
+        launch
+        config
+  )
+endif()

--- a/planning/autoware_tensorrt_vad/CMakeLists.txt
+++ b/planning/autoware_tensorrt_vad/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_tensorrt_vad)
 
 find_package(autoware_cmake REQUIRED)
-
 autoware_package(
     SKIP_LINT
 )

--- a/planning/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
+++ b/planning/autoware_tensorrt_vad/config/ml_package_vad_tiny.param.yaml
@@ -4,6 +4,8 @@
       num_cameras: 6
     interface_params:
       # autoware
+      input_image_width: 1440
+      input_image_height: 1080
       target_image_width: 640
       target_image_height: 384
       detection_range: [-15.0, -30.0, -2.0, 15.0, 30.0, 2.0]

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/input_converter/image_converter.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/input_converter/image_converter.hpp
@@ -3,12 +3,13 @@
 
 #include "autoware/tensorrt_vad/converter.hpp"
 #include <sensor_msgs/msg/image.hpp>
+#include <opencv2/core/mat.hpp>
 #include <vector>
 #include <memory>
 
 namespace autoware::tensorrt_vad::vad_interface {
 
-using CameraImagesData = std::vector<float>;
+using CameraImagesData = std::vector<cv::Mat>;
 
 /**
  * @brief InputImageConverter handles camera image data processing and normalization
@@ -31,7 +32,7 @@ public:
   /**
    * @brief Process multiple camera images for VAD model input
    * @param images Vector of ROS Image messages from multiple cameras
-   * @return CameraImagesData Concatenated normalized image data in CHW format
+   * @return CameraImagesData Vector of cv::Mat images processed for VAD model
    */
   CameraImagesData process_image(
     const std::vector<sensor_msgs::msg::Image::ConstSharedPtr>& images) const;

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess.hpp
@@ -40,7 +40,9 @@ public:
       const std::vector<cv::Mat>& camera_images,
       float* d_output_buffer,
       cudaStream_t stream
-  );private:
+  );
+  
+private:
     /**
      * @brief Validates input image vector (size, format, etc.).
      * @param camera_images Image vector to validate.

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess.hpp
@@ -29,18 +29,18 @@ public:
     MultiCameraPreprocessor(const MultiCameraPreprocessor&) = delete;
     MultiCameraPreprocessor& operator=(const MultiCameraPreprocessor&) = delete;
 
-  /**
-   * @brief Batch preprocess multiple camera images (cv::Mat) on GPU.
-   * @param camera_images Host-side input images (cv::Mat) vector. Should be BGR8 format.
-   * @param d_output_buffer Pointer to device output buffer. Results are written here in CHW format.
-   * @param stream CUDA stream to use for execution.
-   * @return cudaError_t Execution status.
-   */
-  cudaError_t preprocess_images(
-      const std::vector<cv::Mat>& camera_images,
-      float* d_output_buffer,
-      cudaStream_t stream
-  );
+    /**
+     * @brief Batch preprocess multiple camera images (cv::Mat) on GPU.
+     * @param camera_images Host-side input images (cv::Mat) vector. Should be BGR8 format.
+     * @param d_output_buffer Pointer to device output buffer. Results are written here in CHW format.
+     * @param stream CUDA stream to use for execution.
+     * @return cudaError_t Execution status.
+     */
+    cudaError_t preprocess_images(
+        const std::vector<cv::Mat>& camera_images,
+        float* d_output_buffer,
+        cudaStream_t stream
+    );
   
 private:
     /**

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess.hpp
@@ -1,0 +1,78 @@
+#ifndef AUTOWARE_TENSORRT_VAD_MULTI_CAMERA_PREPROCESS_HPP_
+#define AUTOWARE_TENSORRT_VAD_MULTI_CAMERA_PREPROCESS_HPP_
+
+#include <cuda_runtime.h>
+#include <vector>
+#include <cstdint>
+#include <opencv2/core/mat.hpp>  // cv::Matを使用するためにインクルード
+
+/**
+ * @struct MultiCameraPreprocessConfig
+ * @brief CUDAによる前処理に必要な設定パラメータを保持する構造体
+ */
+struct MultiCameraPreprocessConfig {
+    int32_t input_width;
+    int32_t input_height;
+    int32_t output_width;
+    int32_t output_height;
+    int32_t num_cameras;
+    float scale_x;
+    float scale_y;
+    float mean[3];
+    float inverse_std[3];
+};
+
+// CUDAカーネルを起動するホスト側ラッパー関数の前方宣言
+cudaError_t launch_multi_camera_preprocess_kernel(
+    uint8_t** d_input_images,
+    float* d_output,
+    const MultiCameraPreprocessConfig& config,
+    cudaStream_t stream
+);
+
+/**
+ * @class MultiCameraPreprocessor
+ * @brief 複数カメラ画像のGPU前処理パイプラインを管理するクラス
+ *
+ * このクラスは、ホストからのcv::Mat画像の受け取り、デバイスへのコピー、
+ * カスタムCUDAカーネルによるリサイズ・変換・正規化・結合までの一連の流れをカプセル化します。
+ * NPPに依存せず、独自のbilinear interpolationを使用してリサイズを行います。
+ * リソースはコンストラクタで確保(RAII)、デストラクタで解放されます。
+ */
+class MultiCameraPreprocessor {
+public:
+    explicit MultiCameraPreprocessor(const MultiCameraPreprocessConfig& config);
+    ~MultiCameraPreprocessor();
+
+    // コピーコンストラクタとコピー代入演算子を禁止し、リソースの二重解放を防ぐ
+    MultiCameraPreprocessor(const MultiCameraPreprocessor&) = delete;
+    MultiCameraPreprocessor& operator=(const MultiCameraPreprocessor&) = delete;
+
+  /**
+   * @brief 複数台のカメラ画像(cv::Mat)をGPUで一括前処理します。
+   * @param camera_images ホスト側の入力画像(cv::Mat)のベクトル。BGR8フォーマットであること。
+   * @param d_output_buffer デバイス上の出力バッファへのポインタ。結果はここにCHW形式で書き込まれる。
+   * @param stream 実行に使用するCUDAストリーム。
+   * @return cudaError_t 実行ステータス。
+   */
+  cudaError_t preprocess_images(
+      const std::vector<cv::Mat>& camera_images,
+      float* d_output_buffer,
+      cudaStream_t stream
+  );private:
+    /**
+     * @brief 入力画像ベクトルが有効か検証します（サイズ、フォーマットなど）。
+     * @param camera_images 検証対象の画像ベクトル。
+     * @return cudaError_t 検証結果。成功時はcudaSuccess。
+     */
+    cudaError_t validate_input(const std::vector<cv::Mat>& camera_images) const;
+
+    MultiCameraPreprocessConfig config_;
+
+    // --- GPU Buffers ---
+    // 入力バッファ (コンストラクタで確保)
+    uint8_t* d_input_buffer_{nullptr};      // 全ての生入力画像を格納する単一の連続バッファ
+    uint8_t** d_input_image_ptrs_{nullptr}; // d_input_buffer_内の各画像の開始位置を指すポインタ配列
+};
+
+#endif // AUTOWARE_TENSORRT_VAD_MULTI_CAMERA_PREPROCESS_HPP_

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess_kernel.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess_kernel.hpp
@@ -1,0 +1,31 @@
+#ifndef AUTOWARE_TENSORRT_VAD_MULTI_CAMERA_PREPROCESS_KERNEL_HPP_
+#define AUTOWARE_TENSORRT_VAD_MULTI_CAMERA_PREPROCESS_KERNEL_HPP_
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+/**
+ * @struct MultiCameraPreprocessConfig
+ * @brief CUDAによる前処理に必要な設定パラメータを保持する構造体
+ */
+struct MultiCameraPreprocessConfig {
+    int32_t input_width;
+    int32_t input_height;
+    int32_t output_width;
+    int32_t output_height;
+    int32_t num_cameras;
+    float scale_x;
+    float scale_y;
+    float mean[3];
+    float inverse_std[3];
+};
+
+// CUDAカーネルを起動するホスト側ラッパー関数の宣言
+cudaError_t launch_multi_camera_preprocess_kernel(
+    uint8_t** d_input_images,
+    float* d_output,
+    const MultiCameraPreprocessConfig& config,
+    cudaStream_t stream
+);
+
+#endif // AUTOWARE_TENSORRT_VAD_MULTI_CAMERA_PREPROCESS_KERNEL_HPP_

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess_kernel.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess_kernel.hpp
@@ -6,7 +6,7 @@
 
 /**
  * @struct MultiCameraPreprocessConfig
- * @brief CUDAによる前処理に必要な設定パラメータを保持する構造体
+ * @brief Configuration parameters required for CUDA preprocessing
  */
 struct MultiCameraPreprocessConfig {
     int32_t input_width;
@@ -20,7 +20,7 @@ struct MultiCameraPreprocessConfig {
     float inverse_std[3];
 };
 
-// CUDAカーネルを起動するホスト側ラッパー関数の宣言
+// Declaration of host-side wrapper function to launch CUDA kernel
 cudaError_t launch_multi_camera_preprocess_kernel(
     uint8_t** d_input_images,
     float* d_output,

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess_kernel.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess_kernel.hpp
@@ -14,18 +14,38 @@ struct MultiCameraPreprocessConfig {
     int32_t output_width;
     int32_t output_height;
     int32_t num_cameras;
-    float scale_x;
-    float scale_y;
-    float mean[3];
-    float inverse_std[3];
+    float scale_x;             // Scaling factor for x-axis (input_width / output_width)
+    float scale_y;             // Scaling factor for y-axis (input_height / output_height)
+    float mean[3];             // Mean values for normalization [R, G, B]
+    float inverse_std[3];      // Inverse standard deviation values [R, G, B]
 };
 
-// Declaration of host-side wrapper function to launch CUDA kernel
-cudaError_t launch_multi_camera_preprocess_kernel(
+/**
+ * @brief Launch resize kernel to resize input images to target dimensions
+ * @param d_input_images Array of pointers to input images on device (BGR uint8_t format)
+ * @param d_resized_images Array of pointers to output resized images on device (BGR uint8_t format)
+ * @param config Preprocessing configuration parameters
+ * @param stream CUDA stream for asynchronous execution
+ * @return cudaError_t CUDA error code
+ */
+cudaError_t launch_multi_camera_resize_kernel(
     uint8_t** d_input_images,
+    uint8_t** d_resized_images,
+    const MultiCameraPreprocessConfig& config,
+    cudaStream_t stream);
+
+/**
+ * @brief Launch normalization kernel to convert BGR->RGB, normalize, and format as CHW
+ * @param d_resized_images Array of pointers to resized images on device (BGR uint8_t format)
+ * @param d_output Final output buffer (RGB float CHW format)
+ * @param config Preprocessing configuration parameters
+ * @param stream CUDA stream for asynchronous execution
+ * @return cudaError_t CUDA error code
+ */
+cudaError_t launch_multi_camera_normalize_kernel(
+    uint8_t** d_resized_images,
     float* d_output,
     const MultiCameraPreprocessConfig& config,
-    cudaStream_t stream
-);
+    cudaStream_t stream);
 
 #endif // AUTOWARE_TENSORRT_VAD_MULTI_CAMERA_PREPROCESS_KERNEL_HPP_

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_config.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_config.hpp
@@ -21,6 +21,8 @@
 #include <map>
 #include <array>
 
+#include "networks/preprocess/multi_camera_preprocess.hpp"
+
 namespace autoware::tensorrt_vad
 {
 
@@ -61,6 +63,15 @@ struct VadConfig
   int32_t map_num_classes;
   std::string plugins_path;
   std::vector<NetConfig> nets_config;
+  
+  // Parameters for MultiCameraPreprocessor
+  int32_t input_image_width;
+  int32_t input_image_height;
+  std::array<float, 3> image_normalization_param_mean;
+  std::array<float, 3> image_normalization_param_std;
+  
+  // Helper method to create MultiCameraPreprocessConfig
+  MultiCameraPreprocessConfig create_multi_camera_preprocess_config() const;
 };
 
 }  // namespace autoware::tensorrt_vad

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -192,7 +192,7 @@ public:
                   std::to_string(preprocess_config.input_width) + "x" + std::to_string(preprocess_config.input_height) + 
                   ", output=" + std::to_string(preprocess_config.output_width) + "x" + std::to_string(preprocess_config.output_height) + 
                   ", cameras=" + std::to_string(preprocess_config.num_cameras));
-    preprocessor_ = std::make_unique<MultiCameraPreprocessor>(preprocess_config);
+    preprocessor_ = std::make_unique<MultiCameraPreprocessor>(preprocess_config, logger_);
     logger_->info("MultiCameraPreprocessor initialized successfully");
   }
 

--- a/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
+++ b/planning/autoware_tensorrt_vad/include/autoware/tensorrt_vad/vad_model.hpp
@@ -25,6 +25,7 @@
 #include <cuda_runtime.h>
 #include <NvInfer.h>
 #include <dlfcn.h>
+#include <opencv2/core/mat.hpp>
 #include "networks/net.hpp"
 #include "networks/backbone.hpp"
 #include "networks/head.hpp"
@@ -33,6 +34,7 @@
 #include <autoware/tensorrt_common/tensorrt_common.hpp>
 #include "ros_vad_logger.hpp"
 #include "vad_config.hpp"
+#include "networks/preprocess/multi_camera_preprocess.hpp"
 
 namespace autoware::tensorrt_vad
 {
@@ -87,7 +89,7 @@ struct BBox {
 struct VadInputData
 {
   // Camera image data (multi-camera support)
-  std::vector<float> camera_images;
+  std::vector<cv::Mat> camera_images;
 
   // Shift information (img_metas.0[shift])
   std::vector<float> shift;
@@ -182,6 +184,16 @@ public:
     cudaStreamCreate(&stream_);
 
     nets_ = init_engines(vad_config_.nets_config, vad_config_, backbone_config, head_config, head_no_prev_config);
+    
+    // Initialize MultiCameraPreprocessor
+    MultiCameraPreprocessConfig preprocess_config = vad_config_.create_multi_camera_preprocess_config();
+    // Debug: Print preprocessor configuration
+    logger_->info("Creating MultiCameraPreprocessor with config: input=" + 
+                  std::to_string(preprocess_config.input_width) + "x" + std::to_string(preprocess_config.input_height) + 
+                  ", output=" + std::to_string(preprocess_config.output_width) + "x" + std::to_string(preprocess_config.output_height) + 
+                  ", cameras=" + std::to_string(preprocess_config.num_cameras));
+    preprocessor_ = std::make_unique<MultiCameraPreprocessor>(preprocess_config);
+    logger_->info("MultiCameraPreprocessor initialized successfully");
   }
 
   // Destructor
@@ -243,6 +255,7 @@ public:
 
 private:
   autoware::tensorrt_common::TrtCommonConfig head_trt_config_;
+  std::unique_ptr<MultiCameraPreprocessor> preprocessor_;
 
   std::unordered_map<std::string, std::shared_ptr<Net>> init_engines(
       const std::vector<NetConfig>& nets_config,
@@ -282,7 +295,17 @@ private:
 
   // Helper functions used in infer function
   void load_inputs(const VadInputData& vad_input_data, const std::string& head_name) {
-    nets_["backbone"]->bindings["img"]->load(vad_input_data.camera_images, stream_);
+    // Use MultiCameraPreprocessor to process camera images
+    cudaError_t preprocess_result = preprocessor_->preprocess_images(
+        vad_input_data.camera_images, 
+        static_cast<float*>(nets_["backbone"]->bindings["img"]->ptr), 
+        stream_);
+    
+    if (preprocess_result != cudaSuccess) {
+      logger_->error("CUDA preprocessing failed: " + std::string(cudaGetErrorString(preprocess_result)));
+      return;
+    }
+    
     nets_[head_name]->bindings["img_metas.0[shift]"]->load(vad_input_data.shift, stream_);
     nets_[head_name]->bindings["img_metas.0[lidar2img]"]->load(vad_input_data.vad_base2img, stream_);
     nets_[head_name]->bindings["img_metas.0[can_bus]"]->load(vad_input_data.can_bus, stream_);

--- a/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess.cpp
+++ b/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess.cpp
@@ -5,6 +5,10 @@
 // Note: Template constructor and logging method implementations are now in the header file
 
 MultiCameraPreprocessor::~MultiCameraPreprocessor() {
+    cleanup_cuda_resources();
+}
+
+void MultiCameraPreprocessor::cleanup_cuda_resources() {
     if (d_input_buffer_) {
         cudaFree(d_input_buffer_);
         d_input_buffer_ = nullptr;

--- a/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess.cpp
+++ b/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess.cpp
@@ -34,7 +34,7 @@ cudaError_t MultiCameraPreprocessor::validate_input(const std::vector<cv::Mat>& 
     const size_t expected_input_size = static_cast<size_t>(config_.input_width) * config_.input_height * 3;
     
     for (size_t i = 0; i < camera_images.size(); ++i) {
-        const auto& img = camera_images[i];
+        const auto& img = camera_images.at(i);
         
         // Check if image is empty
         if (img.empty()) {

--- a/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess.cpp
+++ b/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess.cpp
@@ -1,0 +1,122 @@
+#include "autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess.hpp"
+#include <stdexcept>
+#include <rclcpp/rclcpp.hpp>
+
+MultiCameraPreprocessor::MultiCameraPreprocessor(const MultiCameraPreprocessConfig& config) : config_(config) {
+    // --- Allocate Input Buffers ---
+    const size_t single_input_size = static_cast<size_t>(config_.input_width) * config_.input_height * 3;
+    const size_t total_input_size = single_input_size * config_.num_cameras;
+    cudaMalloc(&d_input_buffer_, total_input_size);
+    cudaMalloc(&d_input_image_ptrs_, config_.num_cameras * sizeof(uint8_t*));
+
+    std::vector<uint8_t*> h_input_ptrs(config_.num_cameras);
+    for (int32_t i = 0; i < config_.num_cameras; ++i) {
+        h_input_ptrs[i] = d_input_buffer_ + i * single_input_size;
+    }
+    cudaMemcpy(d_input_image_ptrs_, h_input_ptrs.data(), config_.num_cameras * sizeof(uint8_t*), cudaMemcpyHostToDevice);
+}
+
+MultiCameraPreprocessor::~MultiCameraPreprocessor() {
+    cudaFree(d_input_buffer_);
+    cudaFree(d_input_image_ptrs_);
+}
+
+cudaError_t MultiCameraPreprocessor::validate_input(const std::vector<cv::Mat>& camera_images) const
+{
+    // Check number of cameras
+    if (camera_images.size() != static_cast<size_t>(config_.num_cameras)) {
+        // Debug info: expected vs actual number of cameras
+        printf("Camera count mismatch: expected %d, got %zu\n", config_.num_cameras, camera_images.size());
+        return cudaErrorInvalidValue;
+    }
+
+    const size_t expected_input_size = static_cast<size_t>(config_.input_width) * config_.input_height * 3;
+    
+    for (size_t i = 0; i < camera_images.size(); ++i) {
+        const auto& img = camera_images[i];
+        
+        // Check if image is empty
+        if (img.empty()) {
+            printf("Camera %zu: image is empty\n", i);
+            return cudaErrorInvalidValue;
+        }
+        
+        // Check if image memory is continuous
+        if (!img.isContinuous()) {
+            printf("Camera %zu: image memory is not continuous\n", i);
+            return cudaErrorInvalidValue;
+        }
+        
+        // Check image size and format
+        const size_t actual_size = img.total() * img.elemSize();
+        if (actual_size != expected_input_size) {
+            printf("Camera %zu: size mismatch - expected %zu, got %zu (dims: %dx%dx%d, elemSize: %zu)\n", 
+                   i, expected_input_size, actual_size, img.cols, img.rows, img.channels(), img.elemSize());
+            return cudaErrorInvalidValue;
+        }
+        
+        // Check image format (should be BGR, 3 channels, 8UC3)
+        if (img.channels() != 3 || img.depth() != CV_8U) {
+            printf("Camera %zu: invalid format - channels: %d, depth: %d (expected: 3 channels, CV_8U)\n", 
+                   i, img.channels(), img.depth());
+            return cudaErrorInvalidValue;
+        }
+    }
+
+    return cudaSuccess;
+}
+
+cudaError_t MultiCameraPreprocessor::preprocess_images(
+    const std::vector<cv::Mat>& camera_images,
+    float* d_output_buffer,
+    cudaStream_t stream)
+{
+    // Debug: Print configuration
+    printf("MultiCameraPreprocessor config: input=%dx%d, output=%dx%d, cameras=%d\n",
+           config_.input_width, config_.input_height, 
+           config_.output_width, config_.output_height, config_.num_cameras);
+    
+    // Step 0: 入力データを検証
+    cudaError_t validation_status = validate_input(camera_images);
+    if (validation_status != cudaSuccess) {
+        printf("Input validation failed with error: %s\n", cudaGetErrorString(validation_status));
+        return validation_status;
+    }
+    
+    // Debug: Print validation success
+    printf("Input validation passed for %zu cameras\n", camera_images.size());
+
+    // Step 1: ホスト(cv::Mat)から事前に確保したデバイスバッファへ画像データをコピー
+    const size_t single_input_size = static_cast<size_t>(config_.input_width) * config_.input_height * 3;
+    for (int32_t i = 0; i < config_.num_cameras; ++i) {
+        const auto& img = camera_images.at(i);
+        
+        // 大きな入力バッファ内のコピー先ポインタを計算
+        uint8_t* d_dst = d_input_buffer_ + i * single_input_size;
+        
+        // データを非同期にコピー
+        cudaError_t copy_result = cudaMemcpyAsync(d_dst, img.data, single_input_size, cudaMemcpyHostToDevice, stream);
+        if (copy_result != cudaSuccess) {
+            printf("cudaMemcpyAsync failed for camera %d: %s\n", i, cudaGetErrorString(copy_result));
+            return copy_result;
+        }
+    }
+    
+    printf("Image data copied to GPU successfully\n");
+
+    // Step 2: resize + BGR->RGB変換 + 正規化 + 結合を行うカスタムカーネルを起動
+    cudaError_t kernel_result = launch_multi_camera_preprocess_kernel(
+        d_input_image_ptrs_,
+        d_output_buffer,
+        config_,
+        stream
+    );
+    
+    if (kernel_result != cudaSuccess) {
+        printf("CUDA kernel launch failed: %s\n", cudaGetErrorString(kernel_result));
+    } else {
+        printf("CUDA kernel launched successfully\n");
+    }
+    
+    return kernel_result;
+}

--- a/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess.cpp
+++ b/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess.cpp
@@ -1,32 +1,25 @@
 #include "autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess.hpp"
 #include <stdexcept>
-#include <rclcpp/rclcpp.hpp>
+#include <thread>
 
-MultiCameraPreprocessor::MultiCameraPreprocessor(const MultiCameraPreprocessConfig& config) : config_(config) {
-    // --- Allocate Input Buffers ---
-    const size_t single_input_size = static_cast<size_t>(config_.input_width) * config_.input_height * 3;
-    const size_t total_input_size = single_input_size * config_.num_cameras;
-    cudaMalloc(&d_input_buffer_, total_input_size);
-    cudaMalloc(&d_input_image_ptrs_, config_.num_cameras * sizeof(uint8_t*));
-
-    std::vector<uint8_t*> h_input_ptrs(config_.num_cameras);
-    for (int32_t i = 0; i < config_.num_cameras; ++i) {
-        h_input_ptrs[i] = d_input_buffer_ + i * single_input_size;
-    }
-    cudaMemcpy(d_input_image_ptrs_, h_input_ptrs.data(), config_.num_cameras * sizeof(uint8_t*), cudaMemcpyHostToDevice);
-}
+// Note: Template constructor and logging method implementations are now in the header file
 
 MultiCameraPreprocessor::~MultiCameraPreprocessor() {
-    cudaFree(d_input_buffer_);
-    cudaFree(d_input_image_ptrs_);
+    if (d_input_buffer_) {
+        cudaFree(d_input_buffer_);
+        d_input_buffer_ = nullptr;
+    }
+    if (d_input_image_ptrs_) {
+        cudaFree(d_input_image_ptrs_);
+        d_input_image_ptrs_ = nullptr;
+    }
 }
 
 cudaError_t MultiCameraPreprocessor::validate_input(const std::vector<cv::Mat>& camera_images) const
 {
     // Check number of cameras
     if (camera_images.size() != static_cast<size_t>(config_.num_cameras)) {
-        // Debug info: expected vs actual number of cameras
-        printf("Camera count mismatch: expected %d, got %zu\n", config_.num_cameras, camera_images.size());
+        logger_->error("Camera count mismatch: expected " + std::to_string(config_.num_cameras) + ", got " + std::to_string(camera_images.size()));
         return cudaErrorInvalidValue;
     }
 
@@ -37,28 +30,29 @@ cudaError_t MultiCameraPreprocessor::validate_input(const std::vector<cv::Mat>& 
         
         // Check if image is empty
         if (img.empty()) {
-            printf("Camera %zu: image is empty\n", i);
+            logger_->error("Camera " + std::to_string(i) + ": image is empty");
             return cudaErrorInvalidValue;
         }
         
         // Check if image memory is continuous
         if (!img.isContinuous()) {
-            printf("Camera %zu: image memory is not continuous\n", i);
+            logger_->error("Camera " + std::to_string(i) + ": image memory is not continuous");
             return cudaErrorInvalidValue;
         }
         
         // Check image size and format
         const size_t actual_size = img.total() * img.elemSize();
         if (actual_size != expected_input_size) {
-            printf("Camera %zu: size mismatch - expected %zu, got %zu (dims: %dx%dx%d, elemSize: %zu)\n", 
-                   i, expected_input_size, actual_size, img.cols, img.rows, img.channels(), img.elemSize());
+            logger_->error("Camera " + std::to_string(i) + ": size mismatch - expected " + std::to_string(expected_input_size) + 
+                          ", got " + std::to_string(actual_size) + " (dims: " + std::to_string(img.cols) + "x" + 
+                          std::to_string(img.rows) + "x" + std::to_string(img.channels()) + ", elemSize: " + std::to_string(img.elemSize()) + ")");
             return cudaErrorInvalidValue;
         }
         
         // Check image format (should be BGR, 3 channels, 8UC3)
         if (img.channels() != 3 || img.depth() != CV_8U) {
-            printf("Camera %zu: invalid format - channels: %d, depth: %d (expected: 3 channels, CV_8U)\n", 
-                   i, img.channels(), img.depth());
+            logger_->error("Camera " + std::to_string(i) + ": invalid format - channels: " + std::to_string(img.channels()) + 
+                          ", depth: " + std::to_string(img.depth()) + " (expected: 3 channels, CV_8U)");
             return cudaErrorInvalidValue;
         }
     }
@@ -71,20 +65,18 @@ cudaError_t MultiCameraPreprocessor::preprocess_images(
     float* d_output_buffer,
     cudaStream_t stream)
 {
-    // Debug: Print configuration
-    printf("MultiCameraPreprocessor config: input=%dx%d, output=%dx%d, cameras=%d\n",
-           config_.input_width, config_.input_height, 
-           config_.output_width, config_.output_height, config_.num_cameras);
+    // Debug: Log configuration
+    logger_->debug("Starting CUDA preprocessing for " + std::to_string(camera_images.size()) + " cameras");
     
     // Step 0: 入力データを検証
     cudaError_t validation_status = validate_input(camera_images);
     if (validation_status != cudaSuccess) {
-        printf("Input validation failed with error: %s\n", cudaGetErrorString(validation_status));
+        logger_->error("Input validation failed with error: " + std::string(cudaGetErrorString(validation_status)));
         return validation_status;
     }
     
-    // Debug: Print validation success
-    printf("Input validation passed for %zu cameras\n", camera_images.size());
+    // Debug: Log validation success
+    logger_->debug("Input validation passed for " + std::to_string(camera_images.size()) + " cameras");
 
     // Step 1: ホスト(cv::Mat)から事前に確保したデバイスバッファへ画像データをコピー
     const size_t single_input_size = static_cast<size_t>(config_.input_width) * config_.input_height * 3;
@@ -97,12 +89,12 @@ cudaError_t MultiCameraPreprocessor::preprocess_images(
         // データを非同期にコピー
         cudaError_t copy_result = cudaMemcpyAsync(d_dst, img.data, single_input_size, cudaMemcpyHostToDevice, stream);
         if (copy_result != cudaSuccess) {
-            printf("cudaMemcpyAsync failed for camera %d: %s\n", i, cudaGetErrorString(copy_result));
+            logger_->error("cudaMemcpyAsync failed for camera " + std::to_string(i) + ": " + cudaGetErrorString(copy_result));
             return copy_result;
         }
     }
     
-    printf("Image data copied to GPU successfully\n");
+    logger_->debug("Image data copied to GPU successfully");
 
     // Step 2: resize + BGR->RGB変換 + 正規化 + 結合を行うカスタムカーネルを起動
     cudaError_t kernel_result = launch_multi_camera_preprocess_kernel(
@@ -113,9 +105,9 @@ cudaError_t MultiCameraPreprocessor::preprocess_images(
     );
     
     if (kernel_result != cudaSuccess) {
-        printf("CUDA kernel launch failed: %s\n", cudaGetErrorString(kernel_result));
+        logger_->error("CUDA kernel launch failed: " + std::string(cudaGetErrorString(kernel_result)));
     } else {
-        printf("CUDA kernel launched successfully\n");
+        logger_->debug("CUDA kernel launched successfully");
     }
     
     return kernel_result;

--- a/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess_kernel.cu
+++ b/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess_kernel.cu
@@ -1,0 +1,176 @@
+#include "autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess.hpp" // 設定構造体の定義などを共有
+
+/**
+ * @brief bilinear interpolationを用いて画像リサイズを行うデバイス関数
+ *
+ * @param src_img 元画像のピクセルデータ
+ * @param src_width 元画像の幅
+ * @param src_height 元画像の高さ
+ * @param dst_x 出力画像のx座標
+ * @param dst_y 出力画像のy座標
+ * @param scale_x x方向のスケールファクター (src_width / dst_width)
+ * @param scale_y y方向のスケールファクター (src_height / dst_height)
+ * @return uint3 リサイズされたピクセル値 (BGR)
+ */
+__device__ uint3 bilinear_interpolation_resize(
+    uint8_t* src_img, 
+    int32_t src_width, 
+    int32_t src_height,
+    int32_t dst_x, 
+    int32_t dst_y, 
+    float scale_x, 
+    float scale_y)
+{
+    // 出力座標を入力座標系にマッピング
+    float src_x = (dst_x + 0.5f) * scale_x - 0.5f;
+    float src_y = (dst_y + 0.5f) * scale_y - 0.5f;
+    
+    // 境界をクランプ
+    src_x = fmaxf(0.0f, fminf(src_x, src_width - 1.0f));
+    src_y = fmaxf(0.0f, fminf(src_y, src_height - 1.0f));
+    
+    // 4つの近傍ピクセルの座標
+    int32_t x0 = static_cast<int32_t>(floorf(src_x));
+    int32_t y0 = static_cast<int32_t>(floorf(src_y));
+    int32_t x1 = static_cast<int32_t>(fminf(static_cast<float>(x0 + 1), static_cast<float>(src_width - 1)));
+    int32_t y1 = static_cast<int32_t>(fminf(static_cast<float>(y0 + 1), static_cast<float>(src_height - 1)));
+    
+    // 補間の重み
+    float dx = src_x - x0;
+    float dy = src_y - y0;
+    
+    // 4つの近傍ピクセルの値を取得 (BGRフォーマット)
+    int32_t idx_00 = (y0 * src_width + x0) * 3;
+    int32_t idx_10 = (y0 * src_width + x1) * 3;
+    int32_t idx_01 = (y1 * src_width + x0) * 3;
+    int32_t idx_11 = (y1 * src_width + x1) * 3;
+    
+    uint3 result;
+    
+    // Bチャンネル
+    float b00 = src_img[idx_00 + 0];
+    float b10 = src_img[idx_10 + 0];
+    float b01 = src_img[idx_01 + 0];
+    float b11 = src_img[idx_11 + 0];
+    result.x = static_cast<uint8_t>(
+        b00 * (1 - dx) * (1 - dy) + b10 * dx * (1 - dy) + 
+        b01 * (1 - dx) * dy + b11 * dx * dy);
+    
+    // Gチャンネル
+    float g00 = src_img[idx_00 + 1];
+    float g10 = src_img[idx_10 + 1];
+    float g01 = src_img[idx_01 + 1];
+    float g11 = src_img[idx_11 + 1];
+    result.y = static_cast<uint8_t>(
+        g00 * (1 - dx) * (1 - dy) + g10 * dx * (1 - dy) + 
+        g01 * (1 - dx) * dy + g11 * dx * dy);
+    
+    // Rチャンネル
+    float r00 = src_img[idx_00 + 2];
+    float r10 = src_img[idx_10 + 2];
+    float r01 = src_img[idx_01 + 2];
+    float r11 = src_img[idx_11 + 2];
+    result.z = static_cast<uint8_t>(
+        r00 * (1 - dx) * (1 - dy) + r10 * dx * (1 - dy) + 
+        r01 * (1 - dx) * dy + r11 * dx * dy);
+    
+    return result;
+}
+
+/**
+ * @brief 複数カメラからの画像を一括で前処理するCUDAカーネル
+ *
+ * このカーネルは、カメラごとに1つのブロックグリッド(blockIdx.z)を使用して並列処理を実行します。
+ * 各スレッドは出力画像の1ピクセルを担当し、以下の処理を融合して行います。
+ * - bilinear interpolationを使ったリサイズ
+ * - BGRフォーマットからRGBフォーマットにチャンネルを並べ替える (bgr2rgb)
+ * - 各チャンネルを正規化する ((pixel - mean) * inv_std) (normalization)
+ * - 最終的な連続した出力バッファに結果を書き込む (CHW planar format)
+ * これにより、複数カメラの画像データが1つのテンソルに結合(concatenate)されます。
+ *
+ * @param d_input_images デバイス上の入力BGR画像(uint8_t*)を指すポインタの配列
+ * @param d_output すべての処理結果を格納する単一のデバイス上の出力バッファ(float*)
+ * @param config 前処理に必要なパラメータを含む設定構造体
+ */
+__global__ void multi_camera_preprocess_kernel(
+    uint8_t** d_input_images,
+    float* d_output,
+    const MultiCameraPreprocessConfig config)
+{
+    const int32_t x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int32_t y = blockIdx.y * blockDim.y + threadIdx.y;
+    const int32_t camera_idx = blockIdx.z;
+
+    // グリッド内のスレッドが出力画像の範囲外であれば、何もせずに終了 (境界チェック)
+    if (x >= config.output_width || y >= config.output_height || camera_idx >= config.num_cameras) {
+        return;
+    }
+
+    // このスレッドが担当するカメラの入力画像へのポインタを取得
+    uint8_t* input_img = d_input_images[camera_idx];
+    
+    // bilinear interpolationを使ってリサイズ
+    uint3 resized_pixel = bilinear_interpolation_resize(
+        input_img, 
+        config.input_width, 
+        config.input_height,
+        x, y, 
+        config.scale_x, 
+        config.scale_y);
+    
+    // BGRピクセル値をfloat型として取得し、BGR->RGB変換
+    const float b_val = static_cast<float>(resized_pixel.x);
+    const float g_val = static_cast<float>(resized_pixel.y);
+    const float r_val = static_cast<float>(resized_pixel.z);
+
+    // 正規化 (BGR->RGBの順番で実施)
+    const float norm_r = (r_val - config.mean[0]) * config.inverse_std[0];
+    const float norm_g = (g_val - config.mean[1]) * config.inverse_std[1];
+    const float norm_b = (b_val - config.mean[2]) * config.inverse_std[2];
+
+    // CHW (Planar) フォーマットで出力バッファの対応する位置に書き込む
+    // この書き込み方により、全カメラのデータが連結された一つの大きなテンソルが形成される
+    const int32_t single_camera_plane_size = config.output_width * config.output_height;
+    const int32_t single_camera_total_size = 3 * single_camera_plane_size;
+    const int32_t out_pixel_offset = y * config.output_width + x;
+
+    const int32_t out_idx_base = camera_idx * single_camera_total_size;
+
+    d_output[out_idx_base + 0 * single_camera_plane_size + out_pixel_offset] = norm_r; // Rチャンネル
+    d_output[out_idx_base + 1 * single_camera_plane_size + out_pixel_offset] = norm_g; // Gチャンネル
+    d_output[out_idx_base + 2 * single_camera_plane_size + out_pixel_offset] = norm_b; // Bチャンネル
+}
+
+
+/**
+ * @brief multi_camera_preprocess_kernelを起動するためのホスト側ラッパー関数
+ *
+ * CUDAカーネルの実行に必要なグリッドとブロックのディメンションを計算し、
+ * カーネルを非同期に起動します。
+ */
+cudaError_t launch_multi_camera_preprocess_kernel(
+    uint8_t** d_input_images,
+    float* d_output,
+    const MultiCameraPreprocessConfig& config,
+    cudaStream_t stream)
+{
+    // 1ブロックあたりのスレッド数を定義 (例: 16x16 = 256スレッド)
+    const dim3 threads_per_block(16, 16, 1);
+
+    // 必要なブロック数を計算 (3Dグリッド: 幅, 高さ, カメラ数)
+    const dim3 blocks_per_grid(
+        (config.output_width + threads_per_block.x - 1) / threads_per_block.x,
+        (config.output_height + threads_per_block.y - 1) / threads_per_block.y,
+        config.num_cameras);
+
+    // CUDAカーネルを起動
+    // config構造体は値渡しされる。
+    // CUDAカーネルにパラメータを値渡しすると、CUDAランタイムがそのデータをホスト（CPU側）からデバイス（GPU側）の非常に高速な特殊メモリ空間（コンスタントメモリなど）に自動的にコピーされる
+    // 毎回コピーするほうが良い理由1: データが小さい: MultiCameraPreprocessConfig 構造体は、数個の int32_t と float だけで構成されており、サイズは数十バイト程度と非常に小さいです。
+    // 毎回コピーするほうが良い理由2: コピーが高速: CUDAランタイムは、このような小さなデータ（通常は数百バイトまで）のコピーを極めて高速に行うように最適化されています。このコピーにかかる時間は、画像データ全体のコピーやNPPのリサイズ処理、カーネル本体の実行時間と比較すると、無視できるほどわずかです。
+    multi_camera_preprocess_kernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
+        d_input_images, d_output, config);
+
+    // カーネル起動に関するエラーをチェックして返す
+    return cudaGetLastError();
+}

--- a/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess_kernel.cu
+++ b/planning/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess_kernel.cu
@@ -1,4 +1,4 @@
-#include "autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess.hpp" // 設定構造体の定義などを共有
+#include "autoware/tensorrt_vad/networks/preprocess/multi_camera_preprocess_kernel.hpp" // CUDAカーネル用の設定構造体と宣言
 
 /**
  * @brief bilinear interpolationを用いて画像リサイズを行うデバイス関数

--- a/planning/autoware_tensorrt_vad/lib/vad_config.cpp
+++ b/planning/autoware_tensorrt_vad/lib/vad_config.cpp
@@ -1,0 +1,43 @@
+// Copyright 2025 Shin-kyoto.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/tensorrt_vad/vad_config.hpp"
+
+namespace autoware::tensorrt_vad
+{
+
+MultiCameraPreprocessConfig VadConfig::create_multi_camera_preprocess_config() const
+{
+  MultiCameraPreprocessConfig config;
+  
+  config.input_width = input_image_width;
+  config.input_height = input_image_height;
+  config.output_width = target_image_width;
+  config.output_height = target_image_height;
+  config.num_cameras = num_cameras;
+  
+  // Calculate scale factors for bilinear interpolation
+  config.scale_x = static_cast<float>(input_image_width) / target_image_width;
+  config.scale_y = static_cast<float>(input_image_height) / target_image_height;
+  
+  // Copy normalization parameters
+  for (int32_t i = 0; i < 3; ++i) {
+    config.mean[i] = image_normalization_param_mean[i];
+    config.inverse_std[i] = 1.0f / image_normalization_param_std[i];
+  }
+  
+  return config;
+}
+
+}  // namespace autoware::tensorrt_vad

--- a/planning/autoware_tensorrt_vad/src/vad_node.cpp
+++ b/planning/autoware_tensorrt_vad/src/vad_node.cpp
@@ -316,6 +316,20 @@ VadConfig VadNode::load_vad_config()
   
   vad_config.can_bus_dim = this->declare_parameter<int32_t>("model_params.network_io_params.can_bus_dim");
   vad_config.plugins_path = this->declare_parameter<std::string>("model_params.plugins_path");
+  
+  // Load input image parameters from interface_params
+  vad_config.input_image_width = this->declare_parameter<int32_t>("interface_params.input_image_width");
+  vad_config.input_image_height = this->declare_parameter<int32_t>("interface_params.input_image_height");
+  
+  // Load image normalization parameters from interface_params (already declared)
+  auto image_mean = this->get_parameter("interface_params.image_normalization_param_mean").as_double_array();
+  auto image_std = this->get_parameter("interface_params.image_normalization_param_std").as_double_array();
+  for (size_t i = 0; i < 3 && i < image_mean.size(); ++i) {
+    vad_config.image_normalization_param_mean[i] = static_cast<float>(image_mean[i]);
+  }
+  for (size_t i = 0; i < 3 && i < image_std.size(); ++i) {
+    vad_config.image_normalization_param_std[i] = static_cast<float>(image_std[i]);
+  }
 
   // backbone configuration
   NetConfig backbone_config;


### PR DESCRIPTION
## Description

- Use cuda kernel to preprocess images

## How was this PR tested?

I tested this PR by running autoware.

<details>
<summary>log</summary>

```sh
❯ ros2 launch autoware_tensorrt_vad vad.launch.xml use_sim_time:=true
[INFO] [launch]: All log files can be found below /home/shintarotomie/.ros/log/2025-09-10-18-20-32-469409-DPC2305009-987733
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [vad_node-1]: process started with pid [987734]
[vad_node-1] [INFO 1757496032.643465939] [vad]: TrtCommon configurations loaded (5GB workspace):
[vad_node-1] [INFO 1757496032.643813773] [vad]:   Backbone - ONNX: /home/shintarotomie/autoware_data/vad/sim_vadv1.extract_img_feat.onnx, Precision: fp16
[vad_node-1] [INFO 1757496032.643944818] [vad]:   Head - ONNX: /home/shintarotomie/autoware_data/vad/sim_vadv1_prev.pts_bbox_head.forward.onnx, Precision: fp32
[vad_node-1] [INFO 1757496032.644041646] [vad]:   Head No Prev - ONNX: /home/shintarotomie/autoware_data/vad/sim_vadv1.pts_bbox_head.forward.onnx, Precision: fp32
[vad_node-1] [INFO 1757496032.978434226] [vad]: Initializing TensorRT engine
[vad_node-1] [I] [TRT] Loaded plugin library: /home/shintarotomie/src/github.com/AutomotiveAIChallenge/aichallenge-2025/aichallenge/workspace/src/e2e-utils-beta/install/autoware_tensorrt_plugins/share/autoware_tensorrt_plugins/plugins/libautoware_tensorrt_plugins.so
[vad_node-1] [I] [TRT] [MemUsageChange] Init CUDA: CPU +0, GPU +0, now: CPU 42, GPU 2846 (MiB)
[vad_node-1] [I] [TRT] [MemUsageChange] Init builder kernel library: CPU +2647, GPU +380, now: CPU 2891, GPU 3258 (MiB)
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Input filename:   /home/shintarotomie/autoware_data/vad/sim_vadv1.extract_img_feat.onnx
[vad_node-1] [I] [TRT] ONNX IR version:  0.0.10
[vad_node-1] [I] [TRT] Opset version:    15
[vad_node-1] [I] [TRT] Producer name:    pytorch
[vad_node-1] [I] [TRT] Producer version: 1.12.0
[vad_node-1] [I] [TRT] Domain:           
[vad_node-1] [I] [TRT] Model version:    0
[vad_node-1] [I] [TRT] Doc string:       
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Loading engine
[vad_node-1] [I] [TRT] Plan was created with TensorRT 10.8.0
[vad_node-1] [I] [TRT] Loaded engine size: 50 MiB
[vad_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +114, now: CPU 0, GPU 160 (MiB)
[vad_node-1] [I] [TRT] Network validation
[vad_node-1] [I] [TRT] Engine setup completed
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [I] [TRT] Loaded plugin library: /home/shintarotomie/src/github.com/AutomotiveAIChallenge/aichallenge-2025/aichallenge/workspace/src/e2e-utils-beta/install/autoware_tensorrt_plugins/share/autoware_tensorrt_plugins/plugins/libautoware_tensorrt_plugins.so
[vad_node-1] [I] [TRT] The logger passed into createInferRuntime differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] The logger passed into createInferBuilder differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Input filename:   /home/shintarotomie/autoware_data/vad/sim_vadv1_prev.pts_bbox_head.forward.onnx
[vad_node-1] [I] [TRT] ONNX IR version:  0.0.10
[vad_node-1] [I] [TRT] Opset version:    15
[vad_node-1] [I] [TRT] Producer name:    pytorch
[vad_node-1] [I] [TRT] Producer version: 1.12.0
[vad_node-1] [I] [TRT] Domain:           
[vad_node-1] [I] [TRT] Model version:    0
[vad_node-1] [I] [TRT] Doc string:       
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] No checker registered for op: RotatePlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: RotatePlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: RotatePlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: RotatePlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] Loading engine
[vad_node-1] [I] [TRT] Plan was created with TensorRT 10.8.0
[vad_node-1] [I] [TRT] Loaded engine size: 96 MiB
[vad_node-1] [I] [TRT] [MS] Running engine with multi stream info
[vad_node-1] [I] [TRT] [MS] Number of aux streams is 7
[vad_node-1] [I] [TRT] [MS] Number of total worker streams is 8
[vad_node-1] [I] [TRT] [MS] The main stream provided by execute/enqueue calls is the first worker stream
[vad_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +607, now: CPU 0, GPU 852 (MiB)
[vad_node-1] [I] [TRT] Network validation
[vad_node-1] [I] [TRT] Engine setup completed
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [I] [TRT] Loaded plugin library: /home/shintarotomie/src/github.com/AutomotiveAIChallenge/aichallenge-2025/aichallenge/workspace/src/e2e-utils-beta/install/autoware_tensorrt_plugins/share/autoware_tensorrt_plugins/plugins/libautoware_tensorrt_plugins.so
[vad_node-1] [I] [TRT] The logger passed into createInferRuntime differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] The logger passed into createInferBuilder differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] Input filename:   /home/shintarotomie/autoware_data/vad/sim_vadv1.pts_bbox_head.forward.onnx
[vad_node-1] [I] [TRT] ONNX IR version:  0.0.10
[vad_node-1] [I] [TRT] Opset version:    15
[vad_node-1] [I] [TRT] Producer name:    pytorch
[vad_node-1] [I] [TRT] Producer version: 1.12.0
[vad_node-1] [I] [TRT] Domain:           
[vad_node-1] [I] [TRT] Model version:    0
[vad_node-1] [I] [TRT] Doc string:       
[vad_node-1] [I] [TRT] ----------------------------------------------------------------
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: MultiScaleDeformableAttentionPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: MultiScaleDeformableAttentionPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: MultiScaleDeformableAttentionPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: MultiScaleDeformableAttentionPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] No checker registered for op: SelectAndPadPlugin. Attempting to check as plugin.
[vad_node-1] [I] [TRT] No importer registered for op: SelectAndPadPlugin. Attempting to import as plugin.
[vad_node-1] [I] [TRT] Searching for plugin: SelectAndPadPlugin, plugin_version: 1, plugin_namespace: 
[vad_node-1] [I] [TRT] Successfully created plugin: SelectAndPadPlugin
[vad_node-1] [I] [TRT] Loading engine
[vad_node-1] [I] [TRT] Plan was created with TensorRT 10.8.0
[vad_node-1] [I] [TRT] Loaded engine size: 97 MiB
[vad_node-1] [I] [TRT] [MS] Running engine with multi stream info
[vad_node-1] [I] [TRT] [MS] Number of aux streams is 7
[vad_node-1] [I] [TRT] [MS] Number of total worker streams is 8
[vad_node-1] [I] [TRT] [MS] The main stream provided by execute/enqueue calls is the first worker stream
[vad_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +580, now: CPU 0, GPU 1516 (MiB)
[vad_node-1] [I] [TRT] Network validation
[vad_node-1] [I] [TRT] Engine setup completed
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [W] [TRT] Input profile is empty, skipping validation. If network has dynamic shapes, it might lead to undefined behavior.
[vad_node-1] [INFO 1757496035.466520254] [vad]: VAD model and interface initialized successfully
[vad_node-1] [INFO 1757496035.466607559] [vad]: VAD Node has been initialized - VAD model will be initialized after first callback
[vad_node-1] [ERROR 1757496282.009335601] [vad]: Synchronization strategy indicates data is not ready for inference
[vad_node-1] [INFO 1757496282.804231833] [vad]: mlvl_feats.0 <- backbone[out.0]

```

</details>

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
